### PR TITLE
Fix cases with empty jdeps output

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
@@ -79,7 +79,7 @@ public class RTSUtil {
         StringWriter output = new StringWriter();
         LOGGER.log(Level.FINE, "JDEPS ARGS:" + args);
         Main.run(args.toArray(new String[0]), new PrintWriter(output));
-        return getDepsFromJdepsOutput(output);
+        return output.getBuffer().length() != 0 ? getDepsFromJdepsOutput(output): new HashMap<String, Set<String>>();
     }
 
     public static Map<String, Set<String>> getDepsFromJdepsOutput(StringWriter jdepsOutput) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
@@ -79,6 +79,7 @@ public class RTSUtil {
         StringWriter output = new StringWriter();
         LOGGER.log(Level.FINE, "JDEPS ARGS:" + args);
         Main.run(args.toArray(new String[0]), new PrintWriter(output));
+        // jdeps can return an empty output when run on .jar files with no .class files
         return output.getBuffer().length() != 0 ? getDepsFromJdepsOutput(output) : new HashMap<String, Set<String>>();
     }
 

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
@@ -79,7 +79,7 @@ public class RTSUtil {
         StringWriter output = new StringWriter();
         LOGGER.log(Level.FINE, "JDEPS ARGS:" + args);
         Main.run(args.toArray(new String[0]), new PrintWriter(output));
-        return output.getBuffer().length() != 0 ? getDepsFromJdepsOutput(output): new HashMap<String, Set<String>>();
+        return output.getBuffer().length() != 0 ? getDepsFromJdepsOutput(output) : new HashMap<String, Set<String>>();
     }
 
     public static Map<String, Set<String>> getDepsFromJdepsOutput(StringWriter jdepsOutput) {


### PR DESCRIPTION
When jdeps incrementally builds its cache, sometimes it finds `.jar` files with no `.class` files. This PR will allow jdeps write an empty `.graph` file in those cases.

