### PR TITLE
Pull up yasgl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>jgrapht-core</artifactId>
       <version>0.9.2</version>
     </dependency>
+    <dependency>
+      <groupId>edu.illinois</groupId>
+      <artifactId>yasgl</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/starts-core/pom.xml
+++ b/starts-core/pom.xml
@@ -29,10 +29,5 @@
       <artifactId>org.ekstazi.core</artifactId>
       <version>4.6.2</version>
     </dependency>
-    <dependency>
-      <groupId>edu.illinois</groupId>
-      <artifactId>yasgl</artifactId>
-      <version>1.2</version>
-    </dependency>
   </dependencies>
 </project>

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -20,11 +20,6 @@
   <dependencies>
     <dependency>
       <groupId>edu.illinois</groupId>
-      <artifactId>yasgl</artifactId>
-      <version>1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>edu.illinois</groupId>
       <artifactId>starts-core</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
yasgl is used in both modules. Moving this dependency to root pom.
A side question is should we remove the jgrapht dependency since we are using yasgl now?
