### PR TITLE
Updated libraries for 2 vulnerable dependency paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,13 @@
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-surefire-plugin</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.1</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-tools</artifactId>
-      <version>1.3</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jgrapht</groupId>
@@ -108,6 +108,16 @@
       <groupId>edu.illinois</groupId>
       <artifactId>yasgl</artifactId>
       <version>1.2</version>
+    </dependency>
+    <dependency>
+    	<groupId>org.codehaus.plexus</groupId>
+    	<artifactId>plexus-utils</artifactId>
+    	<version>3.1.0</version>
+    </dependency>
+    <dependency>
+    	<groupId>commons-httpclient</groupId>
+    	<artifactId>commons-httpclient</artifactId>
+    	<version>20020423</version>
     </dependency>
   </dependencies>
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
@@ -148,7 +148,7 @@ abstract class BaseMojo extends SurefirePlugin implements StartsConstants {
         long start = System.currentTimeMillis();
         ClassLoader loader = null;
         try {
-            loader = sfClassPath.createClassLoader(null, false, false, "MyRole");
+            loader = sfClassPath.createClassLoader(false, false, "MyRole");
         } catch (SurefireExecutionException see) {
             see.printStackTrace();
         }


### PR DESCRIPTION
With the below updates the project is successfully building and all tests are passing.

The PR includes:
- pom.xml with updated dependencies and transitive dependencies that do not contain known vulnerabilities

- Minor update to BaseMojo.java based on a change to the maven-surefire-plugin.  Ticket where the plugin was changed, https://issues.apache.org/jira/browse/SUREFIRE-1265, and a link to the updated documentation https://maven.apache.org/surefire/surefire-booter/apidocs/org/apache/maven/surefire/booter/Classpath.html, and the actual commit that changed the maven-sure-fire plugin, https://github.com/apache/maven-surefire/commit/cba4adb1b93002c5b4bb2d2f22f461cc53bd8738#diff-049369803c0e1eee11f166c74db8ffd2.

Updating to maven-surefire-plugin 2.20.1 includes a combined 54 bug fixes and 17 improvements. Details can be found here for 2.20, https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317927&version=12334636, and 2.20.1, https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317927&version=12340297

Since both maven-surefire-plugin@2.19.1 and maven-plugin-testing-tools@1.3 have dependencies on libraries that contain known vulnerabilities this is the reason for updating.  There are five vulnerabilities between the two plugin's dependencies that include a shell command injection, two directory traversals, improper input validation, and potentially a man in the middle attack.  Three of the five vulnerabilities have CVEs associated with them and two of which have known exploits.  While STARTS may not directly use these libraries, they are included in order to build the software which means there is a potential risk to a user or system.

Additional details on the vulnerabilities:
org.codehaus.plexus:plexus-utils introduced through: maven-surefire-plugin@2.19.1;maven-plugin-testing-tools@1.3
https://www.sourceclear.com/registry/security/directory-traversal/java/sid-2859/summary

org.codehaus.plexus:plexus-utils introduced through: maven-surefire-plugin@2.19.1;maven-plugin-testing-tools@1.3 
https://www.sourceclear.com/registry/security/command-line-shell-injection/java/sid-3933/summary

org.apache.jackrabbit:jackrabbit-webdav introduced through: maven-surefire-plugin@2.19.1
https://nvd.nist.gov/vuln/detail/CVE-2015-1833

com.jcraft:jsch introduced through: maven-surefire-plugin@2.19.1
https://nvd.nist.gov/vuln/detail/CVE-2016-5725

commons-httpclient commons-httpclient 3.1 introduced through: maven-surefire-plugin@2.19.1
https://nvd.nist.gov/vuln/detail/CVE-2012-5783
