### PR TITLE
check null obect per EvoSuite test

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Cache.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Cache.java
@@ -46,7 +46,12 @@ public class Cache {
         // Some projects depend directly on jars in the standard library, so
         // we want to check there as well
         jarsInCache.addAll(checkMissingJarsInJDKCache(missing));
-        moreEdges.addAll(loadCachedEdges(jarsInCache));
+        if (moreEdges != null) {
+            moreEdges.addAll(loadCachedEdges(jarsInCache));
+        }
+        else {
+            moreEdges = new ArrayList<String>(loadCachedEdges(jarsInCache));
+        }
     }
 
     private HashSet<String> getJarsMissingFromCache(Set<String> jarsInCache) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Cache.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Cache.java
@@ -48,9 +48,8 @@ public class Cache {
         jarsInCache.addAll(checkMissingJarsInJDKCache(missing));
         if (moreEdges != null) {
             moreEdges.addAll(loadCachedEdges(jarsInCache));
-        }
-        else {
-            moreEdges = new ArrayList<String>(loadCachedEdges(jarsInCache));
+        } else {
+            moreEdges = new ArrayList<>(loadCachedEdges(jarsInCache));
         }
     }
 


### PR DESCRIPTION
This corner case is found by EvoSuite tests. If the input moreEdges is a null object (which is not common but possible), the method addAll will fail.

There is another failure which may be considered as a fake failure when using DirectedGraph.fromGiraphString(). If the input file is a null object, it cannot be read or written.