### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: java
 
-before_install:
-    - jdk_switcher use oraclejdk8
+sudo: false
+  
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode8
 
 script:
-    - mvn clean verify -B
+    - mvn verify -B
+
+cache:
+    directories:
+    - $HOME/.m2


### PR DESCRIPTION
adds build matrix to build on both macOS and linux

adds cache as optimization to avoid redownloading dependencies

removes clean because travis automatically runs mvn install -Dskiptest=true etc... to download dependencies prior to running the script. making the script clean out the previously downloaded dependencies does not make sense