### PR TITLE
speeds up travisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
       jdk: oraclejdk8
     - os: osx
       osx_image: xcode8
+  allow_failures:
+    - os: osx
+  fast_finish: true
 
 script:
     - mvn verify -B


### PR DESCRIPTION
swaps macOS to be optional, and will not impact build status

As you can see from the below screenshot, the linux build completed 3 minutes ago but the macOS one still hasn't started.
This used to delay the travisCI build status, but now that macOS is considered an optional build the build status reflects the linux one and is passing as soon as the linux one is done.

![image](https://user-images.githubusercontent.com/3122063/32971237-dd5cfdca-cbb1-11e7-928c-36fcd48cf4e4.png)
