### PR TITLE
Adding in check for Surefire plugin under pluginManagement, not just the regular build plugins

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
@@ -77,7 +77,8 @@ public class PomUtil implements StartsConstants {
                 break;
             }
         }
-        // Did not find plugin under the default build plugins, but maybe is under pluginManagement
+        // Did not find plugin under <build><plugins>,
+        // check under <build><pluginManagement><plugins>
         if (plugin == null) {
             plugins = project.getPluginManagement().getPlugins();
             for (Plugin p : plugins) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
@@ -77,6 +77,16 @@ public class PomUtil implements StartsConstants {
                 break;
             }
         }
+        // Did not find plugin under the default build plugins, but maybe is under pluginManagement
+        if (plugin == null) {
+            plugins = project.getPluginManagement().getPlugins();
+            for (Plugin p : plugins) {
+                if (p.getKey().equalsIgnoreCase(name)) {
+                    plugin = p;
+                    break;
+                }
+            }
+        }
         return plugin;
     }
 


### PR DESCRIPTION
This PR adds a check for the Surefire plugin in the pluginManagement section of the project, which is actually fairly common. Addresses issue #16.