### PR TITLE
second integration-test run will have results of the first integration-test available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       jdk: oraclejdk8
 
 script:
-    - mvn verify -B
+    - mvn clean verify -B
 
 cache:
     directories:

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -65,7 +65,7 @@
           <addTestClassPath>true</addTestClassPath>
           <debug>false</debug>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-          <cloneClean>true</cloneClean>
+          <cloneClean>false</cloneClean>
           <pomIncludes>
             <pomInclude>*/pom.xml</pomInclude>
           </pomIncludes>

--- a/starts-plugin/src/it/base-it/verify.groovy
+++ b/starts-plugin/src/it/base-it/verify.groovy
@@ -2,16 +2,21 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
-    verifyUtil.assertCorrectlyAffected("1");
+    verifyUtil.assertCorrectlyAffected("1")
+    firstRun.createNewFile()
 } else {
-    verifyUtil.assertCorrectlyAffected("0");
-    verifyUtil.deleteFile(firstRun);
+    verifyUtil.assertCorrectlyAffected("0")
+    resetIT()
+}
+
+def resetIT() {
+    verifyUtil.deleteFile(firstRun)
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/first-it/setup.groovy
+++ b/starts-plugin/src/it/first-it/setup.groovy
@@ -4,10 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-firstRun = new File(basedir, "first-run.txt");
+firstRun = new File(basedir, "first-run.txt")
 
-if (firstRun.exists()){
+if (firstRun.exists()) {
     setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-    file = new File(basedir, "src/main/java/first/First.java");
+    file = new File(basedir, "src/main/java/first/First.java")
     setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
 }

--- a/starts-plugin/src/it/first-it/setup.groovy
+++ b/starts-plugin/src/it/first-it/setup.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
 firstRun = new File(basedir, "first-run.txt")
 

--- a/starts-plugin/src/it/first-it/setup.groovy
+++ b/starts-plugin/src/it/first-it/setup.groovy
@@ -4,6 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/first/First.java");
-setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+firstRun = new File(basedir, "first-run.txt");
+
+if (firstRun.exists()){
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/first/First.java");
+    setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+}

--- a/starts-plugin/src/it/first-it/verify.groovy
+++ b/starts-plugin/src/it/first-it/verify.groovy
@@ -4,6 +4,7 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
+targetDir = new File(basedir, "target");
 firstRun = new File(basedir, "first-run.txt");
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
 verifyUtil.assertCorrectlyAffected("1");
@@ -13,4 +14,7 @@ if (!firstRun.exists()) {
 } else {
     verifyUtil.deleteFile(firstRun);
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    file = new File(basedir, "src/main/java/first/First.java");
+    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
+    verifyUtil.deleteFolder(targetDir);
 }

--- a/starts-plugin/src/it/first-it/verify.groovy
+++ b/starts-plugin/src/it/first-it/verify.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
 firstRun = new File(basedir, "first-run.txt")
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"))

--- a/starts-plugin/src/it/first-it/verify.groovy
+++ b/starts-plugin/src/it/first-it/verify.groovy
@@ -4,17 +4,20 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
-targetDir = new File(basedir, "target");
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
-verifyUtil.assertCorrectlyAffected("1");
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
+verifyUtil.assertCorrectlyAffected("1")
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
+    firstRun.createNewFile()
 } else {
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
-    file = new File(basedir, "src/main/java/first/First.java");
-    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
-    verifyUtil.deleteFolder(targetDir);
+    changedFile = new File(basedir, "src/main/java/first/First.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+    resetIT()
+}
+
+def resetIT() {
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/first-it/verify.groovy
+++ b/starts-plugin/src/it/first-it/verify.groovy
@@ -11,12 +11,13 @@ verifyUtil.assertCorrectlyAffected("1")
 if (!firstRun.exists()) {
     firstRun.createNewFile()
 } else {
-    changedFile = new File(basedir, "src/main/java/first/First.java")
-    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
     resetIT()
 }
 
 def resetIT() {
+    changedFile = new File(basedir, "src/main/java/first/First.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+
     verifyUtil.deleteFile(firstRun)
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
     verifyUtil.deleteFolder(new File(basedir, "target"))

--- a/starts-plugin/src/it/missing-reflection-it/setup.groovy
+++ b/starts-plugin/src/it/missing-reflection-it/setup.groovy
@@ -2,8 +2,12 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/base/Simple.java");
-setupUtil.replaceAllInFile(file, "MissingDependency", "MissedDependency")
+firstRun = new File(basedir, "first-run.txt")
+
+if (firstRun.exists()) {
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/base/Simple.java")
+    setupUtil.replaceAllInFile(file, "MissingDependency", "MissedDependency")
+}

--- a/starts-plugin/src/it/missing-reflection-it/verify.groovy
+++ b/starts-plugin/src/it/missing-reflection-it/verify.groovy
@@ -2,18 +2,26 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
-    verifyUtil.assertCorrectlyAffected("1");
+    verifyUtil.assertCorrectlyAffected("1")
+    firstRun.createNewFile()
 } else {
     // Although we change Simple.java between runs, no test is selected because
     // without reflection-awareness, SimpleTest.java does not depend on Simple.java
-    verifyUtil.assertCorrectlyAffected("0");
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    verifyUtil.assertCorrectlyAffected("0")
+    resetIT()
+}
+
+def resetIT() {
+    changedFile = new File(basedir, "src/main/java/base/Simple.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "MissedDependency", "MissingDependency")
+
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
 firstRun = new File(basedir, "first-run.txt")
 

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
@@ -4,6 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/inter/Child.java");
-setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+firstRun = new File(basedir, "first-run.txt");
+
+if (firstRun.exists()){
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/inter/Child.java");
+    setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/setup.groovy
@@ -4,10 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-firstRun = new File(basedir, "first-run.txt");
+firstRun = new File(basedir, "first-run.txt")
 
-if (firstRun.exists()){
+if (firstRun.exists()) {
     setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-    file = new File(basedir, "src/main/java/inter/Child.java");
+    file = new File(basedir, "src/main/java/inter/Child.java")
     setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
 }

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
@@ -4,6 +4,7 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
+targetDir = new File(basedir, "target");
 firstRun = new File(basedir, "first-run.txt");
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
 
@@ -14,4 +15,7 @@ if (!firstRun.exists()) {
     verifyUtil.assertCorrectlyAffected("2");
     verifyUtil.deleteFile(firstRun);
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    file = new File(basedir, "src/main/java/inter/Child.java");
+    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
+    verifyUtil.deleteFolder(targetDir);
 }

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
 firstRun = new File(basedir, "first-run.txt")
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
@@ -12,11 +12,13 @@ if (!firstRun.exists()) {
     firstRun.createNewFile()
 } else {
     verifyUtil.assertCorrectlyAffected("2")
-    changedFile = new File(basedir, "src/main/java/inter/Child.java")
-    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+    resetIT()
 }
 
 def resetIT() {
+    changedFile = new File(basedir, "src/main/java/inter/Child.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+
     verifyUtil.deleteFile(firstRun)
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
     verifyUtil.deleteFolder(new File(basedir, "target"))

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-it/verify.groovy
@@ -4,18 +4,20 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
-targetDir = new File(basedir, "target");
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
-    verifyUtil.assertCorrectlyAffected("4");
+    verifyUtil.assertCorrectlyAffected("4")
+    firstRun.createNewFile()
 } else {
-    verifyUtil.assertCorrectlyAffected("2");
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
-    file = new File(basedir, "src/main/java/inter/Child.java");
-    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
-    verifyUtil.deleteFolder(targetDir);
+    verifyUtil.assertCorrectlyAffected("2")
+    changedFile = new File(basedir, "src/main/java/inter/Child.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+}
+
+def resetIT() {
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
@@ -4,6 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/base/Child.java");
-setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+firstRun = new File(basedir, "first-run.txt");
+
+if (firstRun.exists()){
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/base/Child.java");
+    setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+}

--- a/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
@@ -4,10 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-firstRun = new File(basedir, "first-run.txt");
+firstRun = new File(basedir, "first-run.txt")
 
-if (firstRun.exists()){
+if (firstRun.exists()) {
     setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-    file = new File(basedir, "src/main/java/base/Child.java");
+    file = new File(basedir, "src/main/java/base/Child.java")
     setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
 }

--- a/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/setup.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
 firstRun = new File(basedir, "first-run.txt")
 

--- a/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
@@ -4,18 +4,22 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
-targetDir = new File(basedir, "target");
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
 
 if (!firstRun.exists()) {
-    verifyUtil.assertCorrectlyAffected("3");
-    firstRun.createNewFile();
+    verifyUtil.assertCorrectlyAffected("3")
+    firstRun.createNewFile()
 } else {
-    verifyUtil.assertCorrectlyAffected("1");
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
-    file = new File(basedir, "src/main/java/base/Child.java");
-    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
-    verifyUtil.deleteFolder(targetDir);
+    verifyUtil.assertCorrectlyAffected("1")
+
+    changedFile = new File(basedir, "src/main/java/base/Child.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+    resetIT()
+}
+
+def resetIT() {
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
@@ -4,6 +4,7 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
+targetDir = new File(basedir, "target");
 firstRun = new File(basedir, "first-run.txt");
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
 
@@ -14,4 +15,7 @@ if (!firstRun.exists()) {
     verifyUtil.assertCorrectlyAffected("1");
     verifyUtil.deleteFile(firstRun);
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    file = new File(basedir, "src/main/java/base/Child.java");
+    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
+    verifyUtil.deleteFolder(targetDir);
 }

--- a/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
+++ b/starts-plugin/src/it/no-parents-or-siblings-it/verify.groovy
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
 firstRun = new File(basedir, "first-run.txt")
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
@@ -12,13 +12,13 @@ if (!firstRun.exists()) {
     firstRun.createNewFile()
 } else {
     verifyUtil.assertCorrectlyAffected("1")
-
-    changedFile = new File(basedir, "src/main/java/base/Child.java")
-    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
     resetIT()
 }
 
 def resetIT() {
+    changedFile = new File(basedir, "src/main/java/base/Child.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+
     verifyUtil.deleteFile(firstRun)
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
     verifyUtil.deleteFolder(new File(basedir, "target"))

--- a/starts-plugin/src/it/one-class-two-tests-it/setup.groovy
+++ b/starts-plugin/src/it/one-class-two-tests-it/setup.groovy
@@ -2,12 +2,12 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
-firstRun = new File(basedir, "first-run.txt");
+firstRun = new File(basedir, "first-run.txt")
 
-if (firstRun.exists()){
+if (firstRun.exists()) {
     setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-    file = new File(basedir, "src/main/java/base/Base.java");
+    file = new File(basedir, "src/main/java/base/Base.java")
     setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
 }

--- a/starts-plugin/src/it/one-class-two-tests-it/setup.groovy
+++ b/starts-plugin/src/it/one-class-two-tests-it/setup.groovy
@@ -4,6 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/base/Base.java");
-setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+firstRun = new File(basedir, "first-run.txt");
+
+if (firstRun.exists()){
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/base/Base.java");
+    setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")
+}

--- a/starts-plugin/src/it/one-class-two-tests-it/verify.groovy
+++ b/starts-plugin/src/it/one-class-two-tests-it/verify.groovy
@@ -4,6 +4,7 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
+targetDir = new File(basedir, "target");
 firstRun = new File(basedir, "first-run.txt");
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
 verifyUtil.assertCorrectlyAffected("2");
@@ -13,4 +14,7 @@ if (!firstRun.exists()) {
 } else {
     verifyUtil.deleteFile(firstRun);
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    file = new File(basedir, "src/main/java/base/Base.java");
+    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
+    verifyUtil.deleteFolder(targetDir);
 }

--- a/starts-plugin/src/it/one-class-two-tests-it/verify.groovy
+++ b/starts-plugin/src/it/one-class-two-tests-it/verify.groovy
@@ -2,19 +2,23 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
-targetDir = new File(basedir, "target");
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
-verifyUtil.assertCorrectlyAffected("2");
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
+verifyUtil.assertCorrectlyAffected("2")
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
+    firstRun.createNewFile()
 } else {
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
-    file = new File(basedir, "src/main/java/base/Base.java");
-    VerifyUtil.replaceAllInFileStatic(file, "Set g", "Set<Integer> g");
-    verifyUtil.deleteFolder(targetDir);
+    resetIT()
+}
+
+def resetIT() {
+    changedFile = new File(basedir, "src/main/java/base/Base.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "Set g", "Set<Integer> g")
+
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/it/transitive-it/setup.groovy
+++ b/starts-plugin/src/it/transitive-it/setup.groovy
@@ -2,12 +2,12 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.SetupUtil;
+import edu.illinois.starts.jdeps.SetupUtil
 
-firstRun = new File(basedir, "first-run.txt");
+firstRun = new File(basedir, "first-run.txt")
 
-if (firstRun.exists()){
+if (firstRun.exists()) {
     setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-    file = new File(basedir, "src/main/java/transitive/Base.java");
+    file = new File(basedir, "src/main/java/transitive/Base.java")
     setupUtil.replaceAllInFile(file, "LinkedHashSet", "HashSet")
 }

--- a/starts-plugin/src/it/transitive-it/setup.groovy
+++ b/starts-plugin/src/it/transitive-it/setup.groovy
@@ -4,6 +4,10 @@
 
 import edu.illinois.starts.jdeps.SetupUtil;
 
-setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
-file = new File(basedir, "src/main/java/transitive/Base.java");
-setupUtil.replaceAllInFile(file, "LinkedHashSet", "HashSet")
+firstRun = new File(basedir, "first-run.txt");
+
+if (firstRun.exists()){
+    setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+    file = new File(basedir, "src/main/java/transitive/Base.java");
+    setupUtil.replaceAllInFile(file, "LinkedHashSet", "HashSet")
+}

--- a/starts-plugin/src/it/transitive-it/verify.groovy
+++ b/starts-plugin/src/it/transitive-it/verify.groovy
@@ -4,6 +4,7 @@
 
 import edu.illinois.starts.jdeps.VerifyUtil;
 
+targetDir = new File(basedir, "target");
 firstRun = new File(basedir, "first-run.txt");
 verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
 verifyUtil.assertCorrectlyAffected("4");
@@ -13,4 +14,7 @@ if (!firstRun.exists()) {
 } else {
     verifyUtil.deleteFile(firstRun);
     verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+    file = new File(basedir, "src/main/java/transitive/Base.java");
+    VerifyUtil.replaceAllInFileStatic(file, "HashSet", "LinkedHashSet");
+    verifyUtil.deleteFolder(targetDir);
 }

--- a/starts-plugin/src/it/transitive-it/verify.groovy
+++ b/starts-plugin/src/it/transitive-it/verify.groovy
@@ -2,19 +2,23 @@
  * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
  */
 
-import edu.illinois.starts.jdeps.VerifyUtil;
+import edu.illinois.starts.jdeps.VerifyUtil
 
-targetDir = new File(basedir, "target");
-firstRun = new File(basedir, "first-run.txt");
-verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
-verifyUtil.assertCorrectlyAffected("4");
+firstRun = new File(basedir, "first-run.txt")
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"))
+verifyUtil.assertCorrectlyAffected("4")
 
 if (!firstRun.exists()) {
-    firstRun.createNewFile();
+    firstRun.createNewFile()
 } else {
-    verifyUtil.deleteFile(firstRun);
-    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
-    file = new File(basedir, "src/main/java/transitive/Base.java");
-    VerifyUtil.replaceAllInFileStatic(file, "HashSet", "LinkedHashSet");
-    verifyUtil.deleteFolder(targetDir);
+    resetIT()
+}
+
+def resetIT() {
+    changedFile = new File(basedir, "src/main/java/transitive/Base.java")
+    VerifyUtil.replaceAllInFileStatic(changedFile, "HashSet", "LinkedHashSet")
+
+    verifyUtil.deleteFile(firstRun)
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"))
+    verifyUtil.deleteFolder(new File(basedir, "target"))
 }

--- a/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
+++ b/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
@@ -7,7 +7,9 @@ package edu.illinois.starts.jdeps;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import edu.illinois.starts.constants.StartsConstants;
@@ -15,7 +17,7 @@ import edu.illinois.starts.constants.StartsConstants;
 import org.junit.Assert;
 
 /**
- * Util methods for scripts that verify results of integration tests.
+ * Util methods for scripts that verify results of integration tests and reset src code to original state.
  */
 public class VerifyUtil implements StartsConstants {
     private List<String> buildLog;
@@ -33,9 +35,33 @@ public class VerifyUtil implements StartsConstants {
         }
     }
 
+    public static void replaceAllInFileStatic(File file, String before, String after) throws IOException {
+        Path path = file.toPath();
+        Charset charset = StandardCharsets.UTF_8;
+        String content = new String(Files.readAllBytes(path), charset);
+        content = content.replaceAll(before, after);
+        Files.write(path, content.getBytes(charset));
+    }
+
     public void deleteFile(File file) {
         if (file.exists()) {
             file.delete();
         }
+    }
+
+    public void deleteFolder(File directory) {
+        if (directory.exists()) {
+            File[] files = directory.listFiles();
+            if (null != files) {
+                for (int i = 0; i < files.length; i++) {
+                    if (files[i].isDirectory()) {
+                        deleteFolder(files[i]);
+                    } else {
+                        files[i].delete();
+                    }
+                }
+            }
+        }
+        directory.delete();
     }
 }

--- a/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
+++ b/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
@@ -61,7 +61,7 @@ public class VerifyUtil implements StartsConstants {
                     }
                 }
             }
+            directory.delete();
         }
-        directory.delete();
     }
 }


### PR DESCRIPTION
maven invoker will no longer reset the cloned ITs between integration-test runs. this is necessary for the second STARTS run to build on top of the first STARTS run, otherwise both runs will be fresh and STARTS will generate new checksums each time, meaning all tests will be selected as affected in both runs (that is not what we want and this fixes that).