### PR TITLE
organizing paths by using a uniform pattern when giving a value

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/helpers/EkstaziHelper.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/EkstaziHelper.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +82,7 @@ public class EkstaziHelper implements StartsConstants {
         if (LOGGER.getLoggingLevel().intValue() > Level.FINEST.intValue()) {
             return changed;
         }
-        String outFilename = artifactsDir + File.separator + CHANGED_CLASSES;
+        String outFilename = Paths.get(artifactsDir, CHANGED_CLASSES).toString();
         for (String line : Arrays.asList(baosErr.toString().split(lineSeparator))) {
             String ekstaziDiffMarker = "::Diff:: ";
             if (line.contains(ekstaziDiffMarker)) {
@@ -103,7 +104,7 @@ public class EkstaziHelper implements StartsConstants {
     }
 
     private static String getRootDirURI(File rootDir) {
-        String artifactsDir = rootDir.getAbsolutePath() + File.separator + ".starts";
+        String artifactsDir = Paths.get(rootDir.getAbsolutePath(), ".starts").toString();
         return (new File(artifactsDir)).toURI().toString();
     }
 

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
@@ -6,6 +6,7 @@ package edu.illinois.starts.helpers;
 
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -187,7 +188,7 @@ public class Loadables implements StartsConstants {
         LOGGER.log(Level.FINEST, "JDEPS CMD: " + args);
         Map<String, Set<String>> depMap = RTSUtil.runJdeps(args);
         if (LOGGER.getLoggingLevel().intValue() == Level.FINEST.intValue()) {
-            Writer.writeMapToFile(depMap, artifactsDir + File.separator + "jdeps-out");
+            Writer.writeMapToFile(depMap, Paths.get(artifactsDir, "jdeps-out").toString());
         }
         return depMap;
     }

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
@@ -39,7 +39,7 @@ public class Writer implements StartsConstants {
     private static final Logger LOGGER = Logger.getGlobal();
 
     public static void writeToFile(Collection col, String filename, String artifactsDir) {
-        String outFilename = artifactsDir + File.separator + filename;
+        String outFilename = Paths.get(artifactsDir, filename).toString();
         writeToFile(col, outFilename);
     }
 
@@ -107,7 +107,7 @@ public class Writer implements StartsConstants {
      */
     public static void writeGraph(DirectedGraph<String> graph, String artifactsDir, boolean print, String graphFile) {
         if (print) {
-            String outFilename = artifactsDir + File.separator + graphFile;
+            String outFilename = Paths.get(artifactsDir, graphFile).toString();
             try (BufferedWriter writer = getWriter(outFilename)) {
                 if (graph == null) {
                     writer.write(EMPTY);
@@ -136,7 +136,7 @@ public class Writer implements StartsConstants {
     }
 
     public static void writeTCSimple(Map<String, Set<String>> testDeps, String artifactsDir, String tcFile) {
-        String outFilename = artifactsDir + File.separator + tcFile;
+        String outFilename = Paths.get(artifactsDir, tcFile).toString();
         try (BufferedWriter writer = getWriter(outFilename)) {
             for (String test : testDeps.keySet()) {
                 writer.write(test + WHITE_SPACE + test);

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 
 import edu.illinois.starts.constants.StartsConstants;
 
@@ -82,20 +83,20 @@ public final class AgentLoader implements StartsConstants {
     private static URL findToolsJar() throws MalformedURLException {
         String javaHome = System.getProperty(JAVA_HOME);
         File javaHomeFile = new File(javaHome);
-        File tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
+        File tjf = new File(javaHomeFile, Paths.get(LIB, TOOLS_JAR_NAME).toString());
 
         if (!tjf.exists()) {
-            tjf = new File(System.getenv("java_home"), LIB + File.separator + TOOLS_JAR_NAME);
+            tjf = new File(System.getenv("java_home"), Paths.get(LIB, TOOLS_JAR_NAME).toString());
         }
 
         if (!tjf.exists() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "jre")) {
             javaHomeFile = javaHomeFile.getParentFile();
-            tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
+            tjf = new File(javaHomeFile, Paths.get(LIB, TOOLS_JAR_NAME).toString());
         }
 
         if (!tjf.exists() && isMac() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "Home")) {
             javaHomeFile = javaHomeFile.getParentFile();
-            tjf = new File(javaHomeFile, "Classes" + File.separator + CLASSES_JAR_NAME);
+            tjf = new File(javaHomeFile, Paths.get("Classes", CLASSES_JAR_NAME).toString());
         }
 
         return tjf.toURI().toURL();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -93,7 +94,7 @@ abstract class BaseMojo extends SurefirePlugin implements StartsConstants {
 
     public String getArtifactsDir() throws MojoExecutionException {
         if (artifactsDir == null) {
-            artifactsDir = basedir.getAbsolutePath() + File.separator + STARTS_DIRECTORY_PATH;
+            artifactsDir = Paths.get(basedir.getAbsolutePath(), STARTS_DIRECTORY_PATH).toString();
             File file = new File(artifactsDir);
             if (!file.mkdirs() && !file.exists()) {
                 throw new MojoExecutionException("I could not create artifacts dir: " + artifactsDir);

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
@@ -174,8 +174,8 @@ public class RunMojo extends DiffMojo implements StartsConstants {
     private String getCleanClassPath(String cp) {
         String[] paths = cp.split(File.pathSeparator);
         StringBuilder sb = new StringBuilder();
-        String classes = File.separator + TARGET +  File.separator + CLASSES;
-        String testClasses = File.separator + TARGET + File.separator + TEST_CLASSES;
+        String classes = File.separator + Paths.get(TARGET, CLASSES);
+        String testClasses = File.separator + Paths.get(TARGET, TEST_CLASSES);
         for (int i = 0; i < paths.length; i++) {
             if (paths[i].contains(classes)
                 || paths[i].contains(testClasses)


### PR DESCRIPTION
Replaced patterns like `String path = "a" + File.separator + "b"` with `String path = Paths.get("a", "b")` as it was requested in #25 