### PR TITLE
Parallel solution of off-line mode

### DIFF
--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>starts-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.twdata.maven</groupId>
+      <artifactId>mojo-executor</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
@@ -79,6 +79,8 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
         } else if (depFormat == DependencyFormat.CLZ) {
             data = EkstaziHelper.getNonAffectedTests(getArtifactsDir());
         }
+        //Try writing (a) to file by configuring log level
+        //Logger.getGlobal().setLoggingLevel(Level.FINEST);
         Set<String> changed = data == null ? new HashSet<String>() : data.getValue();
         if (Logger.getGlobal().getLoggingLevel().intValue() <= Level.FINEST.intValue()) {
             Writer.writeToFile(changed, CHANGED_CLASSES, getArtifactsDir());

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
@@ -79,8 +79,6 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
         } else if (depFormat == DependencyFormat.CLZ) {
             data = EkstaziHelper.getNonAffectedTests(getArtifactsDir());
         }
-        //Try writing (a) to file by configuring log level
-        //Logger.getGlobal().setLoggingLevel(Level.FINEST);
         Set<String> changed = data == null ? new HashSet<String>() : data.getValue();
         if (Logger.getGlobal().getLoggingLevel().intValue() <= Level.FINEST.intValue()) {
             Writer.writeToFile(changed, CHANGED_CLASSES, getArtifactsDir());

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
@@ -110,6 +110,14 @@ public class RunMojo extends DiffMojo implements StartsConstants {
         long startUpdateTime = System.currentTimeMillis();
         if (updateRunChecksums && !enableMojoExecutor) {
             updateForNextRun(nonAffectedTests);
+        } else if (updateRunChecksums && enableMojoExecutor) {
+            try {
+                UpdateMojoRunnable.mutex.acquire();
+                Thread updateThread = new Thread(new UpdateMojoRunnable(writeNonAffected));
+                updateThread.start();
+            } catch (InterruptedException ie) {
+                ie.printStackTrace();
+            }
         }
         long endUpdateTime = System.currentTimeMillis();
         logger.log(Level.FINE, PROFILE_STARTS_MOJO_UPDATE_TIME

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
@@ -65,6 +65,14 @@ public class RunMojo extends DiffMojo implements StartsConstants {
     @Parameter(property = "writeNonAffected", defaultValue = "false")
     protected boolean writeNonAffected;
 
+    /**
+     * Set this to "true" to invoke UpdateMojo in StartsMojo to update checksums and test dependencies.
+     * The default value of "false" will update test dependencies in RunMojo and will not invoke UpdateMojo.
+     * If updateRunChecksums is "false", this option will not affect any behaviour of "starts:starts".
+     */
+    @Parameter(property = "enableMojoExecutor", defaultValue = "false")
+    protected boolean enableMojoExecutor;
+
     protected Set<String> nonAffectedTests;
     protected Set<String> changedClasses;
     private Logger logger;
@@ -100,7 +108,7 @@ public class RunMojo extends DiffMojo implements StartsConstants {
             dynamicallyUpdateExcludes(excludePaths);
         }
         long startUpdateTime = System.currentTimeMillis();
-        if (updateRunChecksums) {
+        if (updateRunChecksums && !enableMojoExecutor) {
             updateForNextRun(nonAffectedTests);
         }
         long endUpdateTime = System.currentTimeMillis();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -6,10 +6,12 @@ package edu.illinois.starts.jdeps;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 
@@ -37,6 +39,11 @@ import org.apache.maven.project.MavenProject;
 public class StartsMojo extends RunMojo implements StartsConstants {
     private Logger logger;
 
+    /**
+     * Set this option and the updateRunChecksums option to "false" together to prevent updating test dependencies
+     * on disk. The default value of "true" invokes UpdateMojo to run updateForNextRun() when updateRunChecksums
+     * is "false". If updateRunChecksums is "true", this option will not affect the behaviour of "starts:starts".
+     */
     @Parameter(property = "enableMojoExecutor", defaultValue = "true")
     private boolean enableMojoExecutor;
     /**
@@ -57,7 +64,6 @@ public class StartsMojo extends RunMojo implements StartsConstants {
     @Component
     private BuildPluginManager pluginManager;
 
-
     public void execute() throws MojoExecutionException {
         long endOfRunMojo = Long.parseLong(System.getProperty(PROFILE_END_OF_RUN_MOJO));
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
@@ -65,7 +71,7 @@ public class StartsMojo extends RunMojo implements StartsConstants {
         long end = System.currentTimeMillis();
         logger.log(Level.FINE, PROFILE_TEST_RUNNING_TIME + Writer.millsToSeconds(end - endOfRunMojo));
 
-        if (enableMojoExecutor) {
+        if (enableMojoExecutor && !updateRunChecksums) {
             executeMojo(
                     plugin(
                             groupId("edu.illinois"),

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -4,32 +4,16 @@
 
 package edu.illinois.starts.jdeps;
 
-import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
-
 import java.util.logging.Level;
 
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.helpers.Writer;
 import edu.illinois.starts.util.Logger;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.MavenProject;
 
 /**
  * Invoked after after running selected tests (see lifecycle.xml for details).
@@ -46,12 +30,19 @@ public class StartsMojo extends RunMojo implements StartsConstants {
         long end = System.currentTimeMillis();
         logger.log(Level.FINE, PROFILE_TEST_RUNNING_TIME + Writer.millsToSeconds(end - endOfRunMojo));
 
-        if (enableMojoExecutor && updateRunChecksums) {
+        if (offlineMode && updateRunChecksums) {
             try {
-                logger.log(Level.FINE, "available Semaphore permits: " + UpdateMojoRunnable.mutex.availablePermits());
+                if (UpdateMojoRunnable.mutex.availablePermits() == 0) {
+                    logger.log(Level.FINEST, "Waiting for UpdateMojo to finish");
+                } else {
+                    logger.log(Level.FINEST, " UpdateMojo has finished. Semaphore permits: "
+                            + UpdateMojoRunnable.mutex.availablePermits());
+                }
                 UpdateMojoRunnable.mutex.acquire();
             } catch (InterruptedException ie) {
                 ie.printStackTrace();
+            } finally {
+                UpdateMojoRunnable.mutex.release();
             }
         }
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -39,12 +39,6 @@ import org.apache.maven.project.MavenProject;
 public class StartsMojo extends RunMojo implements StartsConstants {
     private Logger logger;
 
-    /**
-     * The Maven BuildPluginManager component.
-     */
-    @Component
-    private BuildPluginManager pluginManager;
-
     public void execute() throws MojoExecutionException {
         long endOfRunMojo = Long.parseLong(System.getProperty(PROFILE_END_OF_RUN_MOJO));
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
@@ -54,6 +48,7 @@ public class StartsMojo extends RunMojo implements StartsConstants {
 
         if (enableMojoExecutor && updateRunChecksums) {
             try {
+                logger.log(Level.FINE, "available Semaphore permits: " + UpdateMojoRunnable.mutex.availablePermits());
                 UpdateMojoRunnable.mutex.acquire();
             } catch (InterruptedException ie) {
                 ie.printStackTrace();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -79,7 +79,7 @@ public class StartsMojo extends RunMojo implements StartsConstants {
                             version("1.4-SNAPSHOT")
                     ),
                     goal("update"),
-                    configuration(),
+                    configuration(element(name("writeNonAffected"), String.valueOf(writeNonAffected))),
                     executionEnvironment(mavenProject, mavenSession, pluginManager)
             );
         }

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -40,25 +40,6 @@ public class StartsMojo extends RunMojo implements StartsConstants {
     private Logger logger;
 
     /**
-     * Set this option and the updateRunChecksums option to "false" together to prevent updating test dependencies
-     * on disk. The default value of "true" invokes UpdateMojo to run updateForNextRun() when updateRunChecksums
-     * is "false". If updateRunChecksums is "true", this option will not affect the behaviour of "starts:starts".
-     */
-    @Parameter(property = "enableMojoExecutor", defaultValue = "true")
-    private boolean enableMojoExecutor;
-    /**
-     * The project currently being build.
-     */
-    @Parameter(defaultValue = "${project}", readonly = true)
-    private MavenProject mavenProject;
-
-    /**
-     * The current Maven session.
-     */
-    @Parameter(defaultValue = "${session}", readonly = true)
-    private MavenSession mavenSession;
-
-    /**
      * The Maven BuildPluginManager component.
      */
     @Component
@@ -71,16 +52,16 @@ public class StartsMojo extends RunMojo implements StartsConstants {
         long end = System.currentTimeMillis();
         logger.log(Level.FINE, PROFILE_TEST_RUNNING_TIME + Writer.millsToSeconds(end - endOfRunMojo));
 
-        if (enableMojoExecutor && !updateRunChecksums) {
+        if (enableMojoExecutor && updateRunChecksums) {
             executeMojo(
                     plugin(
-                            groupId("edu.illinois"),
-                            artifactId("starts-maven-plugin"),
-                            version("1.4-SNAPSHOT")
+                            groupId(getProject().getGroupId()),
+                            artifactId(getProject().getArtifactId()),
+                            version(getProject().getVersion())
                     ),
                     goal("update"),
                     configuration(element(name("writeNonAffected"), String.valueOf(writeNonAffected))),
-                    executionEnvironment(mavenProject, mavenSession, pluginManager)
+                    executionEnvironment(getProject(), getSession(), pluginManager)
             );
         }
         end = System.currentTimeMillis();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -4,16 +4,30 @@
 
 package edu.illinois.starts.jdeps;
 
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
 import java.util.logging.Level;
 
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.helpers.Writer;
 import edu.illinois.starts.util.Logger;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Invoked after after running selected tests (see lifecycle.xml for details).
@@ -23,12 +37,47 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class StartsMojo extends RunMojo implements StartsConstants {
     private Logger logger;
 
+    @Parameter(property = "enableMojoExecutor", defaultValue = "true")
+    private boolean enableMojoExecutor;
+    /**
+     * The project currently being build.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+
+    /**
+     * The current Maven session.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession mavenSession;
+
+    /**
+     * The Maven BuildPluginManager component.
+     */
+    @Component
+    private BuildPluginManager pluginManager;
+
+
     public void execute() throws MojoExecutionException {
         long endOfRunMojo = Long.parseLong(System.getProperty(PROFILE_END_OF_RUN_MOJO));
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
         logger = Logger.getGlobal();
         long end = System.currentTimeMillis();
         logger.log(Level.FINE, PROFILE_TEST_RUNNING_TIME + Writer.millsToSeconds(end - endOfRunMojo));
+
+        if (enableMojoExecutor) {
+            executeMojo(
+                    plugin(
+                            groupId("edu.illinois"),
+                            artifactId("starts-maven-plugin"),
+                            version("1.4-SNAPSHOT")
+                    ),
+                    goal("update"),
+                    configuration(),
+                    executionEnvironment(mavenProject, mavenSession, pluginManager)
+            );
+        }
+        end = System.currentTimeMillis();
         logger.log(Level.FINE, "[PROFILE] STARTS-MOJO-TOTAL: " + Writer.millsToSeconds(end - endOfRunMojo));
     }
 }

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/StartsMojo.java
@@ -53,17 +53,13 @@ public class StartsMojo extends RunMojo implements StartsConstants {
         logger.log(Level.FINE, PROFILE_TEST_RUNNING_TIME + Writer.millsToSeconds(end - endOfRunMojo));
 
         if (enableMojoExecutor && updateRunChecksums) {
-            executeMojo(
-                    plugin(
-                            groupId(getProject().getGroupId()),
-                            artifactId(getProject().getArtifactId()),
-                            version(getProject().getVersion())
-                    ),
-                    goal("update"),
-                    configuration(element(name("writeNonAffected"), String.valueOf(writeNonAffected))),
-                    executionEnvironment(getProject(), getSession(), pluginManager)
-            );
+            try {
+                UpdateMojoRunnable.mutex.acquire();
+            } catch (InterruptedException ie) {
+                ie.printStackTrace();
+            }
         }
+
         end = System.currentTimeMillis();
         logger.log(Level.FINE, "[PROFILE] STARTS-MOJO-TOTAL: " + Writer.millsToSeconds(end - endOfRunMojo));
     }

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -54,17 +54,16 @@ public class UpdateMojo extends DiffMojo {
         logger.log(Level.INFO, "********** Update **********");
 
         Set<String> nonAffected = new HashSet<>();
-        String filenameNonAffected = getArtifactsDir() + File.separator + "non-affected-tests";
-        File fileNonAffected = new File(filenameNonAffected);
-        if (writeNonAffected && fileNonAffected.isFile()) {
+        String nonAffectedFilename = getArtifactsDir() + File.separator + "non-affected-tests";
+        File nonAffectedFile = new File(nonAffectedFilename);
+        if (writeNonAffected && nonAffectedFile.isFile()) {
             try {
-                List<String> testNames = Files.readAllLines(fileNonAffected.toPath(), StandardCharsets.UTF_8);
-                nonAffected.addAll(testNames);
+                nonAffected.addAll(Files.readAllLines(nonAffectedFile.toPath(), StandardCharsets.UTF_8));
             } catch (IOException ioe) {
                 ioe.printStackTrace();
             }
             long end = System.currentTimeMillis();
-            logger.log(Level.FINE, "[PROFILE] readFromFile " + filenameNonAffected + " : "
+            logger.log(Level.FINE, "[PROFILE] readFromFile " + nonAffectedFilename + " : "
                     + Writer.millsToSeconds(end - start));
         } else {
             Pair<Set<String>, Set<String>> data = computeChangeData();
@@ -80,18 +79,5 @@ public class UpdateMojo extends DiffMojo {
         long end = System.currentTimeMillis();
         System.setProperty("[PROFILE] END-OF-UPDATE-MOJO: ", Long.toString(end));
         logger.log(Level.FINE, "[PROFILE] UPDATE-MOJO-TOTAL: " + Writer.millsToSeconds(end - start));
-    }
-
-    public Set<String> readFromFile(File inFile, String artifactsDir) {
-        Set<String> result = new HashSet<>();
-        try (BufferedReader reader = new BufferedReader(new FileReader(inFile))) {
-            String className = null;
-            while ((className = reader.readLine()) != null) {
-                result.add(className);
-            }
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-        }
-        return result;
     }
 }

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -44,12 +44,11 @@ public class UpdateMojo extends DiffMojo {
     @Parameter(property = "writeNonAffected", defaultValue = "false")
     private boolean writeNonAffected;
 
-
     private Logger logger;
 
     public void execute() throws MojoExecutionException {
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
-        long start = System.currentTimeMillis();
+        long analysisPhaseStart = System.currentTimeMillis();
         logger = Logger.getGlobal();
         logger.log(Level.INFO, "********** Update **********");
 
@@ -62,9 +61,9 @@ public class UpdateMojo extends DiffMojo {
             } catch (IOException ioe) {
                 ioe.printStackTrace();
             }
-            long end = System.currentTimeMillis();
+            long analysisPhaseEnd = System.currentTimeMillis();
             logger.log(Level.FINE, "[PROFILE] readFromFile " + nonAffectedFilename + " : "
-                    + Writer.millsToSeconds(end - start));
+                    + Writer.millsToSeconds(analysisPhaseEnd - analysisPhaseStart));
         } else {
             Pair<Set<String>, Set<String>> data = computeChangeData();
             if(data != null) nonAffected = data.getKey();
@@ -76,6 +75,7 @@ public class UpdateMojo extends DiffMojo {
             updateForNextRun(nonAffected);
         }
 
+        long start = Long.parseLong(System.getProperty("[PROFILE] START-OF-PARALLEL-UPDATE-MOJO: "));
         long end = System.currentTimeMillis();
         System.setProperty("[PROFILE] END-OF-UPDATE-MOJO: ", Long.toString(end));
         logger.log(Level.FINE, "[PROFILE] UPDATE-MOJO-TOTAL: " + Writer.millsToSeconds(end - start));

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -36,8 +36,14 @@ public class UpdateMojo extends DiffMojo {
     @Parameter(property = "updateDiffChecksums", defaultValue = "true")
     private boolean updateDiffChecksums;
 
+    private Logger logger;
+
     public void execute() throws MojoExecutionException {
+        Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
         long start = System.currentTimeMillis();
+        logger = Logger.getGlobal();
+        logger.log(Level.INFO, "********** Update **********");
+
         Set<String> nonAffected = new HashSet<>();
         String filenameNonAffected = getArtifactsDir() + File.separator + "non-affected-tests";
         File fileNonAffected = new File(filenameNonAffected);
@@ -49,18 +55,22 @@ public class UpdateMojo extends DiffMojo {
                 ioe.printStackTrace();
             }
             long end = System.currentTimeMillis();
-            Logger.getGlobal().log(Level.FINE, "[PROFILE] readFromFile " + filenameNonAffected + " : "
+            logger.log(Level.FINE, "[PROFILE] readFromFile " + filenameNonAffected + " : "
                     + Writer.millsToSeconds(end - start));
         } else {
             Pair<Set<String>, Set<String>> data = computeChangeData();
             if(data != null) nonAffected = data.getKey();
             long end = System.currentTimeMillis();
-            Logger.getGlobal().log(Level.FINE, "[PROFILE] computeChangeData(): "
+            logger.log(Level.FINE, "[PROFILE] computeChangeData(): "
                             + Writer.millsToSeconds(end - start));
         }
         if(updateDiffChecksums) {
             updateForNextRun(nonAffected);
         }
+
+        long end = System.currentTimeMillis();
+        System.setProperty("[PROFILE] END-OF-UPDATE-MOJO: ", Long.toString(end));
+        logger.log(Level.FINE, "[PROFILE] UPDATE-MOJO-TOTAL: " + Writer.millsToSeconds(end - start));
     }
 
     public Set<String> readFromFile(File inFile, String artifactsDir) {

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -36,6 +36,15 @@ public class UpdateMojo extends DiffMojo {
     @Parameter(property = "updateUpdateChecksums", defaultValue = "true")
     private boolean updateUpdateChecksums;
 
+    /**
+     * This should only be set to "true" when the previous run goal set it to true as well.
+     * the previous run goal saves nonAffectedTests as a file on disk when this value is true,
+     * then the update goal can load the file to prevent running computeChangeData() twice.
+     */
+    @Parameter(property = "writeNonAffected", defaultValue = "false")
+    private boolean writeNonAffected;
+
+
     private Logger logger;
 
     public void execute() throws MojoExecutionException {
@@ -47,7 +56,7 @@ public class UpdateMojo extends DiffMojo {
         Set<String> nonAffected = new HashSet<>();
         String filenameNonAffected = getArtifactsDir() + File.separator + "non-affected-tests";
         File fileNonAffected = new File(filenameNonAffected);
-        if (fileNonAffected.isFile()) {
+        if (writeNonAffected && fileNonAffected.isFile()) {
             try {
                 List<String> testNames = Files.readAllLines(fileNonAffected.toPath(), StandardCharsets.UTF_8);
                 nonAffected.addAll(testNames);

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package edu.illinois.starts.jdeps;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+
+import edu.illinois.starts.util.Logger;
+import edu.illinois.starts.util.Pair;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Update test dependencies on disk.
+ */
+@Mojo(name = "update", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
+//Assume the user always run (e) before running this goal
+//@Execute(phase = LifecyclePhase.TEST_COMPILE)
+public class UpdateMojo extends DiffMojo {
+    public void execute() throws MojoExecutionException {
+        Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
+
+        Set<String> changed = new HashSet<>();
+        Set<String> nonAffected = new HashSet<>();
+        Pair<Set<String>, Set<String>> data = computeChangeData();
+        String extraText = "";
+        if (data != null) {
+            nonAffected = data.getKey();
+            changed = data.getValue();
+        } else {
+            extraText = " (no RTS artifacts; likely the first run)";
+        }
+        printResult(changed, "ChangedClasses" + extraText);
+        //updateDiffChecksums is always true for this module
+        updateForNextRun(nonAffected);
+    }
+}

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -29,12 +29,12 @@ import org.apache.maven.plugins.annotations.*;
 @Mojo(name = "update", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class UpdateMojo extends DiffMojo {
     /**
-     * Set this to "false" to prevent checksums from being persisted to disk. This
-     * is useful for "dry runs" where one may want to see the non-affected tests that
-     * STARTS writes to the Surefire excludesFile, without updating test dependencies.
+     * Set this to "false" to prevent checksums from being persisted to disk when
+     * updateRunChecksums is false and to prevent running updateForNextRun() twice
+     * when updateRunChecksums is true.
      */
-    @Parameter(property = "updateDiffChecksums", defaultValue = "true")
-    private boolean updateDiffChecksums;
+    @Parameter(property = "updateUpdateChecksums", defaultValue = "true")
+    private boolean updateUpdateChecksums;
 
     private Logger logger;
 
@@ -64,7 +64,7 @@ public class UpdateMojo extends DiffMojo {
             logger.log(Level.FINE, "[PROFILE] computeChangeData(): "
                             + Writer.millsToSeconds(end - start));
         }
-        if(updateDiffChecksums) {
+        if (updateUpdateChecksums) {
             updateForNextRun(nonAffected);
         }
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -21,7 +21,9 @@ import edu.illinois.starts.helpers.Writer;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Update class and test dependencies.
@@ -66,10 +68,9 @@ public class UpdateMojo extends DiffMojo {
                     + Writer.millsToSeconds(analysisPhaseEnd - analysisPhaseStart));
         } else {
             Pair<Set<String>, Set<String>> data = computeChangeData();
-            if(data != null) nonAffected = data.getKey();
-            long end = System.currentTimeMillis();
-            logger.log(Level.FINE, "[PROFILE] computeChangeData(): "
-                            + Writer.millsToSeconds(end - start));
+            if (data != null) {
+                nonAffected = data.getKey();
+            }
         }
         if (updateUpdateChecksums) {
             updateForNextRun(nonAffected);

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -23,8 +23,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * Update test dependencies on disk.
  */
 @Mojo(name = "update", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
-//Assume the user always run (e) before running this goal
-//@Execute(phase = LifecyclePhase.TEST_COMPILE)
 public class UpdateMojo extends DiffMojo {
     public void execute() throws MojoExecutionException {
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojo.java
@@ -4,6 +4,10 @@
 
 package edu.illinois.starts.jdeps;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 
+import edu.illinois.starts.helpers.Writer;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -20,25 +25,41 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Update test dependencies on disk.
+ * Update class and test dependencies.
  */
 @Mojo(name = "update", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class UpdateMojo extends DiffMojo {
     public void execute() throws MojoExecutionException {
-        Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
-
-        Set<String> changed = new HashSet<>();
-        Set<String> nonAffected = new HashSet<>();
-        Pair<Set<String>, Set<String>> data = computeChangeData();
-        String extraText = "";
-        if (data != null) {
-            nonAffected = data.getKey();
-            changed = data.getValue();
+        long start = System.currentTimeMillis();
+        Set<String> nonAffected = null;
+        String inFilename = getArtifactsDir() + File.separator + "non-affected-tests";
+        File inFile = new File(inFilename);
+        if (inFile.isFile()) {
+            nonAffected = readFromFile(inFile, getArtifactsDir());
+            long end = System.currentTimeMillis();
+            Logger.getGlobal().log(Level.FINE, "[PROFILE] readFromFile " + inFilename + " : "
+                    + Writer.millsToSeconds(end - start));
         } else {
-            extraText = " (no RTS artifacts; likely the first run)";
+            Pair<Set<String>, Set<String>> data = computeChangeData();
+            nonAffected = data == null ? new HashSet<String>() : data.getKey();
+            long end = System.currentTimeMillis();
+            Logger.getGlobal().log(Level.FINE, "[PROFILE] computeChangeData(): "
+                            + Writer.millsToSeconds(end - start));
         }
-        printResult(changed, "ChangedClasses" + extraText);
-        //updateDiffChecksums is always true for this module
+        //updateDiffChecksums is always true for this mojo
         updateForNextRun(nonAffected);
+    }
+
+    public Set<String> readFromFile(File inFile, String artifactsDir) {
+        Set<String> result = new HashSet<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(inFile))) {
+            String className = null;
+            while ((className = reader.readLine()) != null) {
+                result.add(className);
+            }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+        return result;
     }
 }

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojoRunnable.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/UpdateMojoRunnable.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package edu.illinois.starts.jdeps;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.logging.Level;
+
+import edu.illinois.starts.helpers.Writer;
+import edu.illinois.starts.util.Logger;
+import edu.illinois.starts.util.Pair;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.surefire.SurefirePlugin;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Update class and test dependencies.
+ */
+public class UpdateMojoRunnable extends SurefirePlugin implements Runnable {
+    static Semaphore mutex = new Semaphore(1);
+
+    /**
+     * This should only be set to "true" when the previous run goal set it to true as well.
+     * the previous run goal saves nonAffectedTests as a file on disk when this value is true,
+     * then the update goal can load the file to prevent running computeChangeData() twice.
+     */
+    private boolean writeNonAffected;
+
+    /**
+     * The Maven BuildPluginManager component.
+     */
+    @Component
+    private BuildPluginManager pluginManager;
+
+    private Logger logger;
+
+    public UpdateMojoRunnable(boolean writeNonAffected) {
+        this.writeNonAffected = writeNonAffected;
+    }
+
+    public void run() {
+        try {
+            executeMojo(
+                    plugin(
+                            groupId(getProject().getGroupId()),
+                            artifactId(getProject().getArtifactId()),
+                            version(getProject().getVersion())
+                    ),
+                    goal("update"),
+                    configuration(element(name("writeNonAffected"), String.valueOf(writeNonAffected))),
+                    executionEnvironment(getProject(), getSession(), pluginManager)
+            );
+            mutex.release();
+        } catch (MojoExecutionException mee) {
+            mee.printStackTrace();
+        }
+    }
+}

--- a/starts-plugin/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/starts-plugin/src/main/resources/META-INF/maven/lifecycle.xml
@@ -25,7 +25,7 @@
         <id>starts-graph</id>
         <phases>
             <phase>
-                <id>process-test-classes</id>
+                <id>initialize</id>
                 <executions>
                     <execution>
                         <goals>

--- a/starts-plugin/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/starts-plugin/src/main/resources/META-INF/maven/lifecycle.xml
@@ -21,4 +21,19 @@
             </phase>
         </phases>
     </lifecycle>
+    <lifecycle>
+        <id>starts-graph</id>
+        <phases>
+            <phase>
+                <id>process-test-classes</id>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>update</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </phase>
+        </phases>
+    </lifecycle>
 </lifecycles>


### PR DESCRIPTION
Usage: `mvn starts:starts -DwriteNonAffected=true -DofflineMode=true`

This is my final solution of the offline mode of `starts:starts` which runs e phase (test running) and g phase (dependency graph updating) in parallel. 

Since PR #44 has not yet been merged, building the code of this (`parallel`) branch in my repo does not work properly. Please try building the `parallel-before-rebase` branch instead if you would like to see how it works before merging.