### PR TITLE
Update deps.zlc if classpath changes

### DIFF
--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
@@ -4,7 +4,6 @@
 
 package edu.illinois.starts.jdeps;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,7 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
 
         Set<String> changed = new HashSet<>();
         Set<String> nonAffected = new HashSet<>();
-        Pair<Set<String>, Set<String>> data = computeChangeData();
+        Pair<Set<String>, Set<String>> data = computeChangeData(false);
         String extraText = EMPTY;
         if (data != null) {
             nonAffected = data.getKey();
@@ -70,7 +69,7 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
         }
     }
 
-    protected Pair<Set<String>, Set<String>> computeChangeData() throws MojoExecutionException {
+    protected Pair<Set<String>, Set<String>> computeChangeData(boolean writeChanged) throws MojoExecutionException {
         long start = System.currentTimeMillis();
         Pair<Set<String>, Set<String>> data = null;
         if (depFormat == DependencyFormat.ZLC) {
@@ -80,7 +79,7 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
             data = EkstaziHelper.getNonAffectedTests(getArtifactsDir());
         }
         Set<String> changed = data == null ? new HashSet<String>() : data.getValue();
-        if (Logger.getGlobal().getLoggingLevel().intValue() <= Level.FINEST.intValue()) {
+        if (writeChanged || Logger.getGlobal().getLoggingLevel().intValue() <= Level.FINEST.intValue()) {
             Writer.writeToFile(changed, CHANGED_CLASSES, getArtifactsDir());
         }
         long end = System.currentTimeMillis();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
@@ -56,7 +56,7 @@ public class ImpactedMojo extends DiffMojo implements StartsConstants {
     public void execute() throws MojoExecutionException {
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
         logger = Logger.getGlobal();
-        Pair<Set<String>, Set<String>> data = computeChangeData();
+        Pair<Set<String>, Set<String>> data = computeChangeData(false);
         // 0. Find all classes in program
         List<String> allClasses = getAllClasses();
         if (allClasses.isEmpty()) {

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/SelectMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/SelectMojo.java
@@ -50,7 +50,7 @@ public class SelectMojo extends DiffMojo implements StartsConstants {
         setIncludesExcludes();
         Set<String> allTests = new HashSet<>(getTestClasses(CHECK_IF_ALL_AFFECTED));
         Set<String> affectedTests = new HashSet<>(allTests);
-        Pair<Set<String>, Set<String>> data = computeChangeData();
+        Pair<Set<String>, Set<String>> data = computeChangeData(false);
         Set<String> nonAffectedTests = data == null ? new HashSet<String>() : data.getKey();
         affectedTests.removeAll(nonAffectedTests);
         if (allTests.equals(nonAffectedTests)) {


### PR DESCRIPTION
When retestAll is done because of classpath changes, we *should* update deps.zlc. #44 was not doing this

Allow users to optionally write `changed-classes` file

Some more cleanup