### PR TITLE
Make STARTS compatible with Java 9 - 15

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B verify --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,28 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java-version: [8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Build with Maven
+        run: mvn -B install --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,16 +13,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
     strategy:
       matrix:
-        java-version: [8]
+        java-version: [8, 9, 10, 11, 12, 13, 14, 15]
+      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java-version }}
-      - name: Build with Maven
-        run: mvn -B install --file pom.xml
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java-version }}
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djdk.attach.allowAttachSelf=true

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jacoco.version>0.7.8</jacoco.version>
+    <jacoco.version>0.8.6</jacoco.version>
   </properties>
 
   <dependencies>

--- a/starts-core/pom.xml
+++ b/starts-core/pom.xml
@@ -38,6 +38,7 @@
         </configuration>
       </plugin>
         <plugin>
+            <!-- Using compiler version 8 to allow method reference -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>

--- a/starts-core/pom.xml
+++ b/starts-core/pom.xml
@@ -20,13 +20,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.8</version>
-      <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
-    </dependency>
-    <dependency>
       <groupId>org.ekstazi</groupId>
       <artifactId>org.ekstazi.core</artifactId>
       <version>4.6.2</version>

--- a/starts-core/pom.xml
+++ b/starts-core/pom.xml
@@ -37,6 +37,14 @@
           </archive>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/starts-core/src/main/java/edu/illinois/starts/asm/AnnotationVisitor.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/AnnotationVisitor.java
@@ -32,8 +32,8 @@ package edu.illinois.starts.asm;
 
 /**
  * A visitor to visit a Java annotation. The methods of this class must be
- * called in the following order: ( <tt>visit</tt> | <tt>visitEnum</tt> |
- * <tt>visitAnnotation</tt> | <tt>visitArray</tt> )* <tt>visitEnd</tt>.
+ * called in the following order: ( <code>visit</code> | <code>visitEnum</code> |
+ * <code>visitAnnotation</code> | <code>visitArray</code> )* <code>visitEnd</code>.
  *
  * @author Eric Bruneton
  * @author Eugene Kuleshov
@@ -126,7 +126,7 @@ public abstract class AnnotationVisitor {
      * @param desc
      *            the class descriptor of the nested annotation class.
      * @return a visitor to visit the actual nested annotation value, or
-     *         <tt>null</tt> if this visitor is not interested in visiting this
+     *         <code>null</code> if this visitor is not interested in visiting this
      *         nested annotation. <i>The nested annotation value must be fully
      *         visited before calling other methods on this annotation
      *         visitor</i>.
@@ -147,7 +147,7 @@ public abstract class AnnotationVisitor {
      * @param name
      *            the value name.
      * @return a visitor to visit the actual array value elements, or
-     *         <tt>null</tt> if this visitor is not interested in visiting these
+     *         <code>null</code> if this visitor is not interested in visiting these
      *         values. The 'name' parameters passed to the methods of this
      *         visitor are ignored. <i>All the array values must be visited
      *         before calling other methods on this annotation visitor</i>.

--- a/starts-core/src/main/java/edu/illinois/starts/asm/AnnotationWriter.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/AnnotationWriter.java
@@ -49,7 +49,7 @@ final class AnnotationWriter extends AnnotationVisitor {
     private int size;
 
     /**
-     * <tt>true</tt> if values are named, <tt>false</tt> otherwise. Annotation
+     * <code>true</code> if values are named, <code>false</code> otherwise. Annotation
      * writers used for annotation default and annotation arrays use unnamed
      * values.
      */
@@ -94,13 +94,13 @@ final class AnnotationWriter extends AnnotationVisitor {
      * @param cw
      *            the class writer to which this annotation must be added.
      * @param named
-     *            <tt>true<tt> if values are named, <tt>false</tt> otherwise.
+     *            <code>true<code> if values are named, <code>false</code> otherwise.
      * @param bv
      *            where the annotation values must be stored.
      * @param parent
      *            where the number of annotation values must be stored.
      * @param offset
-     *            where in <tt>parent</tt> the number of annotation values must
+     *            where in <code>parent</code> the number of annotation values must
      *            be stored.
      */
     AnnotationWriter(final ClassWriter cw, final boolean named,
@@ -326,7 +326,7 @@ final class AnnotationWriter extends AnnotationVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param out
      *            where the type reference and type path must be put.
      */

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Attribute.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Attribute.java
@@ -50,7 +50,7 @@ public class Attribute {
     byte[] value;
 
     /**
-     * The next attribute in this attribute list. May be <tt>null</tt>.
+     * The next attribute in this attribute list. May be <code>null</code>.
      */
     Attribute next;
 
@@ -65,19 +65,19 @@ public class Attribute {
     }
 
     /**
-     * Returns <tt>true</tt> if this type of attribute is unknown. The default
-     * implementation of this method always returns <tt>true</tt>.
+     * Returns <code>true</code> if this type of attribute is unknown. The default
+     * implementation of this method always returns <code>true</code>.
      *
-     * @return <tt>true</tt> if this type of attribute is unknown.
+     * @return <code>true</code> if this type of attribute is unknown.
      */
     public boolean isUnknown() {
         return true;
     }
 
     /**
-     * Returns <tt>true</tt> if this type of attribute is a code attribute.
+     * Returns <code>true</code> if this type of attribute is a code attribute.
      *
-     * @return <tt>true</tt> if this type of attribute is a code attribute.
+     * @return <code>true</code> if this type of attribute is a code attribute.
      */
     public boolean isCodeAttribute() {
         return false;
@@ -86,7 +86,7 @@ public class Attribute {
     /**
      * Returns the labels corresponding to this attribute.
      *
-     * @return the labels corresponding to this attribute, or <tt>null</tt> if
+     * @return the labels corresponding to this attribute, or <code>null</code> if
      *         this attribute is not a code attribute that contains labels.
      */
     protected Label[] getLabels() {
@@ -96,7 +96,7 @@ public class Attribute {
     /**
      * Reads a {@link #type type} attribute. This method must return a
      * <i>new</i> {@link Attribute} object, of type {@link #type type},
-     * corresponding to the <tt>len</tt> bytes starting at the given offset, in
+     * corresponding to the <code>len</code> bytes starting at the given offset, in
      * the given class reader.
      *
      * @param cr
@@ -119,7 +119,7 @@ public class Attribute {
      *            containing the type and the length of the attribute, are not
      *            taken into account here.
      * @param labels
-     *            the labels of the method's code, or <tt>null</tt> if the
+     *            the labels of the method's code, or <code>null</code> if the
      *            attribute to be read is not a code attribute.
      * @return a <i>new</i> {@link Attribute} object corresponding to the given
      *         bytes.
@@ -142,11 +142,11 @@ public class Attribute {
      *            class the items that corresponds to this attribute.
      * @param code
      *            the bytecode of the method corresponding to this code
-     *            attribute, or <tt>null</tt> if this attribute is not a code
+     *            attribute, or <code>null</code> if this attribute is not a code
      *            attributes.
      * @param len
      *            the length of the bytecode of the method corresponding to this
-     *            code attribute, or <tt>null</tt> if this attribute is not a
+     *            code attribute, or <code>null</code> if this attribute is not a
      *            code attribute.
      * @param maxStack
      *            the maximum stack size of the method corresponding to this
@@ -189,11 +189,11 @@ public class Attribute {
      *            byte arrays, with the {@link #write write} method.
      * @param code
      *            the bytecode of the method corresponding to these code
-     *            attributes, or <tt>null</tt> if these attributes are not code
+     *            attributes, or <code>null</code> if these attributes are not code
      *            attributes.
      * @param len
      *            the length of the bytecode of the method corresponding to
-     *            these code attributes, or <tt>null</tt> if these attributes
+     *            these code attributes, or <code>null</code> if these attributes
      *            are not code attributes.
      * @param maxStack
      *            the maximum stack size of the method corresponding to these
@@ -227,11 +227,11 @@ public class Attribute {
      *            byte arrays, with the {@link #write write} method.
      * @param code
      *            the bytecode of the method corresponding to these code
-     *            attributes, or <tt>null</tt> if these attributes are not code
+     *            attributes, or <code>null</code> if these attributes are not code
      *            attributes.
      * @param len
      *            the length of the bytecode of the method corresponding to
-     *            these code attributes, or <tt>null</tt> if these attributes
+     *            these code attributes, or <code>null</code> if these attributes
      *            are not code attributes.
      * @param maxStack
      *            the maximum stack size of the method corresponding to these

--- a/starts-core/src/main/java/edu/illinois/starts/asm/ByteVector.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/ByteVector.java
@@ -304,7 +304,7 @@ public class ByteVector {
      * automatically enlarged if necessary.
      *
      * @param b
-     *            an array of bytes. May be <tt>null</tt> to put <tt>len</tt>
+     *            an array of bytes. May be <code>null</code> to put <code>len</code>
      *            null bytes into this byte vector.
      * @param off
      *            index of the fist byte of b that must be copied.

--- a/starts-core/src/main/java/edu/illinois/starts/asm/ClassReader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/ClassReader.java
@@ -247,7 +247,7 @@ public class ClassReader {
      * {@link Type#getInternalName() getInternalName}). For interfaces, the
      * super class is {@link Object}.
      *
-     * @return the internal name of super class, or <tt>null</tt> for
+     * @return the internal name of super class, or <code>null</code> for
      *         {@link Object} class.
      *
      * @see ClassVisitor#visit(int, int, String, String, String, String[])
@@ -261,7 +261,7 @@ public class ClassReader {
      * {@link Type#getInternalName() getInternalName}).
      *
      * @return the array of internal names for all implemented interfaces or
-     *         <tt>null</tt>.
+     *         <code>null</code>.
      *
      * @see ClassVisitor#visit(int, int, String, String, String, String[])
      */
@@ -1720,7 +1720,7 @@ public class ClassReader {
      * @param v
      *            start offset in {@link #b b} of the annotations to be read.
      * @param visible
-     *            <tt>true</tt> if the annotations to be read are visible at
+     *            <code>true</code> if the annotations to be read are visible at
      *            runtime.
      */
     private void readParameterAnnotations(final MethodVisitor mv,
@@ -2232,9 +2232,9 @@ public class ClassReader {
      *            and the length of the attribute, are not taken into account
      *            here.
      * @param labels
-     *            the labels of the method's code, or <tt>null</tt> if the
+     *            the labels of the method's code, or <code>null</code> if the
      *            attribute to be read is not a code attribute.
-     * @return the attribute that has been read, or <tt>null</tt> to skip this
+     * @return the attribute that has been read, or <code>null</code> to skip this
      *         attribute.
      */
     private Attribute readAttribute(final Attribute[] attrs, final String type,

--- a/starts-core/src/main/java/edu/illinois/starts/asm/ClassVisitor.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/ClassVisitor.java
@@ -32,11 +32,11 @@ package edu.illinois.starts.asm;
 
 /**
  * A visitor to visit a Java class. The methods of this class must be called in
- * the following order: <tt>visit</tt> [ <tt>visitSource</tt> ] [
- * <tt>visitOuterClass</tt> ] ( <tt>visitAnnotation</tt> |
- * <tt>visitTypeAnnotation</tt> | <tt>visitAttribute</tt> )* (
- * <tt>visitInnerClass</tt> | <tt>visitField</tt> | <tt>visitMethod</tt> )*
- * <tt>visitEnd</tt>.
+ * the following order: <code>visit</code> [ <code>visitSource</code> ] [
+ * <code>visitOuterClass</code> ] ( <code>visitAnnotation</code> |
+ * <code>visitTypeAnnotation</code> | <code>visitAttribute</code> )* (
+ * <code>visitInnerClass</code> | <code>visitField</code> | <code>visitMethod</code> )*
+ * <code>visitEnd</code>.
  *
  * @author Eric Bruneton
  */
@@ -95,18 +95,18 @@ public abstract class ClassVisitor {
      *            the internal name of the class (see
      *            {@link Type#getInternalName() getInternalName}).
      * @param signature
-     *            the signature of this class. May be <tt>null</tt> if the class
+     *            the signature of this class. May be <code>null</code> if the class
      *            is not a generic one, and does not extend or implement generic
      *            classes or interfaces.
      * @param superName
      *            the internal of name of the super class (see
      *            {@link Type#getInternalName() getInternalName}). For
      *            interfaces, the super class is {@link Object}. May be
-     *            <tt>null</tt>, but only for the {@link Object} class.
+     *            <code>null</code>, but only for the {@link Object} class.
      * @param interfaces
      *            the internal names of the class's interfaces (see
      *            {@link Type#getInternalName() getInternalName}). May be
-     *            <tt>null</tt>.
+     *            <code>null</code>.
      */
     public void visit(int version, int access, String name, String signature,
             String superName, String[] interfaces) {
@@ -120,11 +120,11 @@ public abstract class ClassVisitor {
      *
      * @param source
      *            the name of the source file from which the class was compiled.
-     *            May be <tt>null</tt>.
+     *            May be <code>null</code>.
      * @param debug
      *            additional debug information to compute the correspondance
      *            between source and compiled elements of the class. May be
-     *            <tt>null</tt>.
+     *            <code>null</code>.
      */
     public void visitSource(String source, String debug) {
         if (cv != null) {
@@ -140,11 +140,11 @@ public abstract class ClassVisitor {
      *            internal name of the enclosing class of the class.
      * @param name
      *            the name of the method that contains the class, or
-     *            <tt>null</tt> if the class is not enclosed in a method of its
+     *            <code>null</code> if the class is not enclosed in a method of its
      *            enclosing class.
      * @param desc
      *            the descriptor of the method that contains the class, or
-     *            <tt>null</tt> if the class is not enclosed in a method of its
+     *            <code>null</code> if the class is not enclosed in a method of its
      *            enclosing class.
      */
     public void visitOuterClass(String owner, String name, String desc) {
@@ -159,8 +159,8 @@ public abstract class ClassVisitor {
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
@@ -184,12 +184,12 @@ public abstract class ClassVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitTypeAnnotation(int typeRef,
@@ -225,10 +225,10 @@ public abstract class ClassVisitor {
      * @param outerName
      *            the internal name of the class to which the inner class
      *            belongs (see {@link Type#getInternalName() getInternalName}).
-     *            May be <tt>null</tt> for not member classes.
+     *            May be <code>null</code> for not member classes.
      * @param innerName
      *            the (simple) name of the inner class inside its enclosing
-     *            class. May be <tt>null</tt> for anonymous inner classes.
+     *            class. May be <code>null</code> for anonymous inner classes.
      * @param access
      *            the access flags of the inner class as originally declared in
      *            the enclosing class.
@@ -251,20 +251,20 @@ public abstract class ClassVisitor {
      * @param desc
      *            the field's descriptor (see {@link Type Type}).
      * @param signature
-     *            the field's signature. May be <tt>null</tt> if the field's
+     *            the field's signature. May be <code>null</code> if the field's
      *            type does not use generic types.
      * @param value
      *            the field's initial value. This parameter, which may be
-     *            <tt>null</tt> if the field does not have an initial value,
+     *            <code>null</code> if the field does not have an initial value,
      *            must be an {@link Integer}, a {@link Float}, a {@link Long}, a
-     *            {@link Double} or a {@link String} (for <tt>int</tt>,
-     *            <tt>float</tt>, <tt>long</tt> or <tt>String</tt> fields
+     *            {@link Double} or a {@link String} (for <code>int</code>,
+     *            <code>float</code>, <code>long</code> or <code>String</code> fields
      *            respectively). <i>This parameter is only used for static
      *            fields</i>. Its value is ignored for non static fields, which
      *            must be initialized through bytecode instructions in
      *            constructors or methods.
      * @return a visitor to visit field annotations and attributes, or
-     *         <tt>null</tt> if this class visitor is not interested in visiting
+     *         <code>null</code> if this class visitor is not interested in visiting
      *         these annotations and attributes.
      */
     public FieldVisitor visitField(int access, String name, String desc,
@@ -277,7 +277,7 @@ public abstract class ClassVisitor {
 
     /**
      * Visits a method of the class. This method <i>must</i> return a new
-     * {@link MethodVisitor} instance (or <tt>null</tt>) each time it is called,
+     * {@link MethodVisitor} instance (or <code>null</code>) each time it is called,
      * i.e., it should not return a previously returned visitor.
      *
      * @param access
@@ -289,14 +289,14 @@ public abstract class ClassVisitor {
      * @param desc
      *            the method's descriptor (see {@link Type Type}).
      * @param signature
-     *            the method's signature. May be <tt>null</tt> if the method
+     *            the method's signature. May be <code>null</code> if the method
      *            parameters, return type and exceptions do not use generic
      *            types.
      * @param exceptions
      *            the internal names of the method's exception classes (see
      *            {@link Type#getInternalName() getInternalName}). May be
-     *            <tt>null</tt>.
-     * @return an object to visit the byte code of the method, or <tt>null</tt>
+     *            <code>null</code>.
+     * @return an object to visit the byte code of the method, or <code>null</code>
      *         if this class visitor is not interested in visiting the code of
      *         this method.
      */

--- a/starts-core/src/main/java/edu/illinois/starts/asm/ClassWriter.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/ClassWriter.java
@@ -332,8 +332,8 @@ public class ClassWriter extends ClassVisitor {
      * A type table used to temporarily store internal names that will not
      * necessarily be stored in the constant pool. This type table is used by
      * the control flow and data flow analysis algorithm used to compute stack
-     * map frames from scratch. This array associates to each index <tt>i</tt>
-     * the Item whose index is <tt>i</tt>. All Item objects stored in this array
+     * map frames from scratch. This array associates to each index <code>i</code>
+     * the Item whose index is <code>i</code>. All Item objects stored in this array
      * are also stored in the {@link #items} hash table. These two arrays allow
      * to retrieve an Item from its index or, conversely, to get the index of an
      * Item from its value. Each Item stores an internal name in its
@@ -485,18 +485,18 @@ public class ClassWriter extends ClassVisitor {
     MethodWriter lastMethod;
 
     /**
-     * <tt>true</tt> if the maximum stack size and number of local variables
+     * <code>true</code> if the maximum stack size and number of local variables
      * must be automatically computed.
      */
     private boolean computeMaxs;
 
     /**
-     * <tt>true</tt> if the stack map frames must be recomputed from scratch.
+     * <code>true</code> if the stack map frames must be recomputed from scratch.
      */
     private boolean computeFrames;
 
     /**
-     * <tt>true</tt> if the stack map tables of this class are invalid. The
+     * <code>true</code> if the stack map tables of this class are invalid. The
      * {@link MethodWriter#resizeInstructions} method cannot transform existing
      * stack map tables, and so produces potentially invalid classes when it is
      * executed. In this case the class is reread and rewritten with the
@@ -1396,7 +1396,7 @@ public class ClassWriter extends ClassVisitor {
      * @param desc
      *            the method's descriptor.
      * @param itf
-     *            <tt>true</tt> if <tt>owner</tt> is an interface.
+     *            <code>true</code> if <code>owner</code> is an interface.
      * @return a new or already existing method reference item.
      */
     Item newMethodItem(final String owner, final String name,
@@ -1425,7 +1425,7 @@ public class ClassWriter extends ClassVisitor {
      * @param desc
      *            the method's descriptor.
      * @param itf
-     *            <tt>true</tt> if <tt>owner</tt> is an interface.
+     *            <code>true</code> if <code>owner</code> is an interface.
      * @return the index of a new or already existing method reference item.
      */
     public int newMethod(final String owner, final String name,
@@ -1707,7 +1707,7 @@ public class ClassWriter extends ClassVisitor {
      * @param key
      *            a constant pool item.
      * @return the constant pool's hash table item which is equal to the given
-     *         item, or <tt>null</tt> if there is no such item.
+     *         item, or <code>null</code> if there is no such item.
      */
     private Item get(final Item key) {
         Item i = items[key.hashCode % items.length];

--- a/starts-core/src/main/java/edu/illinois/starts/asm/FieldVisitor.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/FieldVisitor.java
@@ -32,8 +32,8 @@ package edu.illinois.starts.asm;
 
 /**
  * A visitor to visit a Java field. The methods of this class must be called in
- * the following order: ( <tt>visitAnnotation</tt> |
- * <tt>visitTypeAnnotation</tt> | <tt>visitAttribute</tt> )* <tt>visitEnd</tt>.
+ * the following order: ( <code>visitAnnotation</code> |
+ * <code>visitTypeAnnotation</code> | <code>visitAttribute</code> )* <code>visitEnd</code>.
  *
  * @author Eric Bruneton
  */
@@ -86,8 +86,8 @@ public abstract class FieldVisitor {
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
@@ -107,12 +107,12 @@ public abstract class FieldVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitTypeAnnotation(int typeRef,

--- a/starts-core/src/main/java/edu/illinois/starts/asm/FieldWriter.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/FieldWriter.java
@@ -72,28 +72,28 @@ final class FieldWriter extends FieldVisitor {
     private int value;
 
     /**
-     * The runtime visible annotations of this field. May be <tt>null</tt>.
+     * The runtime visible annotations of this field. May be <code>null</code>.
      */
     private AnnotationWriter anns;
 
     /**
-     * The runtime invisible annotations of this field. May be <tt>null</tt>.
+     * The runtime invisible annotations of this field. May be <code>null</code>.
      */
     private AnnotationWriter ianns;
 
     /**
-     * The runtime visible type annotations of this field. May be <tt>null</tt>.
+     * The runtime visible type annotations of this field. May be <code>null</code>.
      */
     private AnnotationWriter tanns;
 
     /**
      * The runtime invisible type annotations of this field. May be
-     * <tt>null</tt>.
+     * <code>null</code>.
      */
     private AnnotationWriter itanns;
 
     /**
-     * The non standard attributes of this field. May be <tt>null</tt>.
+     * The non standard attributes of this field. May be <code>null</code>.
      */
     private Attribute attrs;
 
@@ -113,9 +113,9 @@ final class FieldWriter extends FieldVisitor {
      * @param desc
      *            the field's descriptor (see {@link Type}).
      * @param signature
-     *            the field's signature. May be <tt>null</tt>.
+     *            the field's signature. May be <code>null</code>.
      * @param value
-     *            the field's constant value. May be <tt>null</tt>.
+     *            the field's constant value. May be <code>null</code>.
      */
     FieldWriter(final ClassWriter cw, final int access, final String name,
                 final String desc, final String signature, final Object value) {

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Frame.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Frame.java
@@ -1271,7 +1271,7 @@ final class Frame {
 
     /**
      * Merges the input frame of the given basic block with the input and output
-     * frames of this basic block. Returns <tt>true</tt> if the input frame of
+     * frames of this basic block. Returns <code>true</code> if the input frame of
      * the given label has been changed by this operation.
      *
      * @param cw
@@ -1281,7 +1281,7 @@ final class Frame {
      * @param edge
      *            the kind of the {@link Edge} between this label and 'label'.
      *            See {@link Edge#info}.
-     * @return <tt>true</tt> if the input frame of the given label has been
+     * @return <code>true</code> if the input frame of the given label has been
      *         changed by this operation.
      */
     boolean merge(final ClassWriter cw, final Frame frame, final int edge) {
@@ -1379,7 +1379,7 @@ final class Frame {
 
     /**
      * Merges the type at the given index in the given type array with the given
-     * type. Returns <tt>true</tt> if the type array has been modified by this
+     * type. Returns <code>true</code> if the type array has been modified by this
      * operation.
      *
      * @param cw
@@ -1390,7 +1390,7 @@ final class Frame {
      *            an array of types.
      * @param index
      *            the index of the type that must be merged in 'types'.
-     * @return <tt>true</tt> if the type array has been modified by this
+     * @return <code>true</code> if the type array has been modified by this
      *         operation.
      */
     private static boolean merge(final ClassWriter cw, int t,

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Handler.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Handler.java
@@ -54,7 +54,7 @@ class Handler {
 
     /**
      * Internal name of the type of exceptions handled by this handler, or
-     * <tt>null</tt> to catch any exceptions.
+     * <code>null</code> to catch any exceptions.
      */
     String desc;
 

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Item.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Item.java
@@ -274,8 +274,8 @@ final class Item {
      * @param i
      *            the item to be compared to this one. Both items must have the
      *            same {@link #type}.
-     * @return <tt>true</tt> if the given item if equal to this one,
-     *         <tt>false</tt> otherwise.
+     * @return <code>true</code> if the given item if equal to this one,
+     *         <code>false</code> otherwise.
      */
     boolean isEqualTo(final Item i) {
         switch (type) {

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Label.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Label.java
@@ -292,8 +292,8 @@ public class Label {
      *            the position of first byte of the bytecode instruction that
      *            contains this label.
      * @param wideOffset
-     *            <tt>true</tt> if the reference must be stored in 4 bytes, or
-     *            <tt>false</tt> if it must be stored with 2 bytes.
+     *            <code>true</code> if the reference must be stored in 4 bytes, or
+     *            <code>false</code> if it must be stored with 2 bytes.
      * @throws IllegalArgumentException
      *             if this label has not been created by the given code writer.
      */
@@ -356,7 +356,7 @@ public class Label {
      *            the position of this label in the bytecode.
      * @param data
      *            the bytecode of the method.
-     * @return <tt>true</tt> if a blank that was left for this label was to
+     * @return <code>true</code> if a blank that was left for this label was to
      *         small to store the offset. In such a case the corresponding jump
      *         instruction is replaced with a pseudo instruction (using unused
      *         opcodes) using an unsigned two bytes offset. These pseudo

--- a/starts-core/src/main/java/edu/illinois/starts/asm/MethodVisitor.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/MethodVisitor.java
@@ -32,23 +32,23 @@ package edu.illinois.starts.asm;
 
 /**
  * A visitor to visit a Java method. The methods of this class must be called in
- * the following order: ( <tt>visitParameter</tt> )* [
- * <tt>visitAnnotationDefault</tt> ] ( <tt>visitAnnotation</tt> |
- * <tt>visitTypeAnnotation</tt> | <tt>visitAttribute</tt> )* [
- * <tt>visitCode</tt> ( <tt>visitFrame</tt> | <tt>visit<i>X</i>Insn</tt> |
- * <tt>visitLabel</tt> | <tt>visitInsnAnnotation</tt> |
- * <tt>visitTryCatchBlock</tt> | <tt>visitTryCatchBlockAnnotation</tt> |
- * <tt>visitLocalVariable</tt> | <tt>visitLocalVariableAnnotation</tt> |
- * <tt>visitLineNumber</tt> )* <tt>visitMaxs</tt> ] <tt>visitEnd</tt>. In
- * addition, the <tt>visit<i>X</i>Insn</tt> and <tt>visitLabel</tt> methods must
+ * the following order: ( <code>visitParameter</code> )* [
+ * <code>visitAnnotationDefault</code> ] ( <code>visitAnnotation</code> |
+ * <code>visitTypeAnnotation</code> | <code>visitAttribute</code> )* [
+ * <code>visitCode</code> ( <code>visitFrame</code> | <code>visit<i>X</i>Insn</code> |
+ * <code>visitLabel</code> | <code>visitInsnAnnotation</code> |
+ * <code>visitTryCatchBlock</code> | <code>visitTryCatchBlockAnnotation</code> |
+ * <code>visitLocalVariable</code> | <code>visitLocalVariableAnnotation</code> |
+ * <code>visitLineNumber</code> )* <code>visitMaxs</code> ] <code>visitEnd</code>. In
+ * addition, the <code>visit<i>X</i>Insn</code> and <code>visitLabel</code> methods must
  * be called in the sequential order of the bytecode instructions of the visited
- * code, <tt>visitInsnAnnotation</tt> must be called <i>after</i> the annotated
- * instruction, <tt>visitTryCatchBlock</tt> must be called <i>before</i> the
+ * code, <code>visitInsnAnnotation</code> must be called <i>after</i> the annotated
+ * instruction, <code>visitTryCatchBlock</code> must be called <i>before</i> the
  * labels passed as arguments have been visited,
- * <tt>visitTryCatchBlockAnnotation</tt> must be called <i>after</i> the
+ * <code>visitTryCatchBlockAnnotation</code> must be called <i>after</i> the
  * corresponding try catch block has been visited, and the
- * <tt>visitLocalVariable</tt>, <tt>visitLocalVariableAnnotation</tt> and
- * <tt>visitLineNumber</tt> methods must be called <i>after</i> the labels
+ * <code>visitLocalVariable</code>, <code>visitLocalVariableAnnotation</code> and
+ * <code>visitLineNumber</code> methods must be called <i>after</i> the labels
  * passed as arguments have been visited.
  *
  * @author Eric Bruneton
@@ -106,8 +106,8 @@ public abstract class MethodVisitor {
      * @param name
      *            parameter name or null if none is provided.
      * @param access
-     *            the parameter's access flags, only <tt>ACC_FINAL</tt>,
-     *            <tt>ACC_SYNTHETIC</tt> or/and <tt>ACC_MANDATED</tt> are
+     *            the parameter's access flags, only <code>ACC_FINAL</code>,
+     *            <code>ACC_SYNTHETIC</code> or/and <code>ACC_MANDATED</code> are
      *            allowed (see {@link Opcodes}).
      */
     public void visitParameter(String name, int access) {
@@ -123,7 +123,7 @@ public abstract class MethodVisitor {
      * Visits the default value of this annotation interface method.
      *
      * @return a visitor to the visit the actual default value of this
-     *         annotation interface method, or <tt>null</tt> if this visitor is
+     *         annotation interface method, or <code>null</code> if this visitor is
      *         not interested in visiting this default value. The 'name'
      *         parameters passed to the methods of this annotation visitor are
      *         ignored. Moreover, exacly one visit method must be called on this
@@ -142,8 +142,8 @@ public abstract class MethodVisitor {
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
@@ -170,12 +170,12 @@ public abstract class MethodVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitTypeAnnotation(int typeRef,
@@ -197,8 +197,8 @@ public abstract class MethodVisitor {
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitParameterAnnotation(int parameter,
@@ -585,7 +585,7 @@ public abstract class MethodVisitor {
      *            the constant to be loaded on the stack. This parameter must be
      *            a non null {@link Integer}, a {@link Float}, a {@link Long}, a
      *            {@link Double}, a {@link String}, a {@link Type} of OBJECT or
-     *            ARRAY sort for <tt>.class</tt> constants, for classes whose
+     *            ARRAY sort for <code>.class</code> constants, for classes whose
      *            version is 49.0, a {@link Type} of METHOD sort or a
      *            {@link Handle} for MethodType and MethodHandle constants, for
      *            classes whose version is 51.0.
@@ -620,8 +620,8 @@ public abstract class MethodVisitor {
      * @param dflt
      *            beginning of the default handler block.
      * @param labels
-     *            beginnings of the handler blocks. <tt>labels[i]</tt> is the
-     *            beginning of the handler block for the <tt>min + i</tt> key.
+     *            beginnings of the handler blocks. <code>labels[i]</code> is the
+     *            beginning of the handler block for the <code>min + i</code> key.
      */
     public void visitTableSwitchInsn(int min, int max, Label dflt,
             Label... labels) {
@@ -638,8 +638,8 @@ public abstract class MethodVisitor {
      * @param keys
      *            the values of the keys.
      * @param labels
-     *            beginnings of the handler blocks. <tt>labels[i]</tt> is the
-     *            beginning of the handler block for the <tt>keys[i]</tt> key.
+     *            beginnings of the handler blocks. <code>labels[i]</code> is the
+     *            beginning of the handler block for the <code>keys[i]</code> key.
      */
     public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
         if (mv != null) {
@@ -684,12 +684,12 @@ public abstract class MethodVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitInsnAnnotation(int typeRef,
@@ -718,7 +718,7 @@ public abstract class MethodVisitor {
      *            beginning of the exception handler's code.
      * @param type
      *            internal name of the type of exceptions handled by the
-     *            handler, or <tt>null</tt> to catch any exceptions (for
+     *            handler, or <code>null</code> to catch any exceptions (for
      *            "finally" blocks).
      * @throws IllegalArgumentException
      *             if one of the labels has already been visited by this visitor
@@ -744,12 +744,12 @@ public abstract class MethodVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitTryCatchAnnotation(int typeRef,
@@ -772,7 +772,7 @@ public abstract class MethodVisitor {
      *            the type descriptor of this local variable.
      * @param signature
      *            the type signature of this local variable. May be
-     *            <tt>null</tt> if the local variable type does not use generic
+     *            <code>null</code> if the local variable type does not use generic
      *            types.
      * @param start
      *            the first instruction corresponding to the scope of this local
@@ -804,7 +804,7 @@ public abstract class MethodVisitor {
      * @param typePath
      *            the path to the annotated type argument, wildcard bound, array
      *            element type, or static inner type within 'typeRef'. May be
-     *            <tt>null</tt> if the annotation targets 'typeRef' as a whole.
+     *            <code>null</code> if the annotation targets 'typeRef' as a whole.
      * @param start
      *            the fist instructions corresponding to the continuous ranges
      *            that make the scope of this local variable (inclusive).
@@ -818,8 +818,8 @@ public abstract class MethodVisitor {
      * @param desc
      *            the class descriptor of the annotation class.
      * @param visible
-     *            <tt>true</tt> if the annotation is visible at runtime.
-     * @return a visitor to visit the annotation values, or <tt>null</tt> if
+     *            <code>true</code> if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or <code>null</code> if
      *         this visitor is not interested in visiting this annotation.
      */
     public AnnotationVisitor visitLocalVariableAnnotation(int typeRef,
@@ -844,7 +844,7 @@ public abstract class MethodVisitor {
      * @param start
      *            the first instruction corresponding to this line number.
      * @throws IllegalArgumentException
-     *             if <tt>start</tt> has not already been visited by this
+     *             if <code>start</code> has not already been visited by this
      *             visitor (by the {@link #visitLabel visitLabel} method).
      */
     public void visitLineNumber(int line, Label start) {

--- a/starts-core/src/main/java/edu/illinois/starts/asm/MethodWriter.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/MethodWriter.java
@@ -178,41 +178,41 @@ class MethodWriter extends MethodVisitor {
     int[] exceptions;
 
     /**
-     * The annotation default attribute of this method. May be <tt>null</tt>.
+     * The annotation default attribute of this method. May be <code>null</code>.
      */
     private ByteVector annd;
 
     /**
-     * The runtime visible annotations of this method. May be <tt>null</tt>.
+     * The runtime visible annotations of this method. May be <code>null</code>.
      */
     private AnnotationWriter anns;
 
     /**
-     * The runtime invisible annotations of this method. May be <tt>null</tt>.
+     * The runtime invisible annotations of this method. May be <code>null</code>.
      */
     private AnnotationWriter ianns;
 
     /**
-     * The runtime visible type annotations of this method. May be <tt>null</tt>
+     * The runtime visible type annotations of this method. May be <code>null</code>
      * .
      */
     private AnnotationWriter tanns;
 
     /**
      * The runtime invisible type annotations of this method. May be
-     * <tt>null</tt>.
+     * <code>null</code>.
      */
     private AnnotationWriter itanns;
 
     /**
      * The runtime visible parameter annotations of this method. May be
-     * <tt>null</tt>.
+     * <code>null</code>.
      */
     private AnnotationWriter[] panns;
 
     /**
      * The runtime invisible parameter annotations of this method. May be
-     * <tt>null</tt>.
+     * <code>null</code>.
      */
     private AnnotationWriter[] ipanns;
 
@@ -341,12 +341,12 @@ class MethodWriter extends MethodVisitor {
     private int lastCodeOffset;
 
     /**
-     * The runtime visible type annotations of the code. May be <tt>null</tt>.
+     * The runtime visible type annotations of the code. May be <code>null</code>.
      */
     private AnnotationWriter ctanns;
 
     /**
-     * The runtime invisible type annotations of the code. May be <tt>null</tt>.
+     * The runtime invisible type annotations of the code. May be <code>null</code>.
      */
     private AnnotationWriter ictanns;
 
@@ -410,7 +410,7 @@ class MethodWriter extends MethodVisitor {
      * is relative to the beginning of the current basic block, i.e., the true
      * stack size after the last visited instruction is equal to the
      * {@link Label#inputStackTop beginStackSize} of the current basic block
-     * plus <tt>stackSize</tt>.
+     * plus <code>stackSize</code>.
      */
     private int stackSize;
 
@@ -419,7 +419,7 @@ class MethodWriter extends MethodVisitor {
      * This size is relative to the beginning of the current basic block, i.e.,
      * the true maximum stack size after the last visited instruction is equal
      * to the {@link Label#inputStackTop beginStackSize} of the current basic
-     * block plus <tt>stackSize</tt>.
+     * block plus <code>stackSize</code>.
      */
     private int maxStackSize;
 
@@ -439,15 +439,15 @@ class MethodWriter extends MethodVisitor {
      * @param desc
      *            the method's descriptor (see {@link Type}).
      * @param signature
-     *            the method's signature. May be <tt>null</tt>.
+     *            the method's signature. May be <code>null</code>.
      * @param exceptions
      *            the internal names of the method's exceptions. May be
-     *            <tt>null</tt>.
+     *            <code>null</code>.
      * @param computeMaxs
-     *            <tt>true</tt> if the maximum stack size and number of local
+     *            <code>true</code> if the maximum stack size and number of local
      *            variables must be automatically computed.
      * @param computeFrames
-     *            <tt>true</tt> if the stack map tables must be recomputed from
+     *            <code>true</code> if the stack map tables must be recomputed from
      *            scratch.
      */
     MethodWriter(final ClassWriter cw, final int access, final String name,
@@ -2846,7 +2846,7 @@ class MethodWriter extends MethodVisitor {
      * Computes the future value of a bytecode offset.
      * <p>
      * Note: it is possible to have several entries for the same instruction in
-     * the <tt>indexes</tt> and <tt>sizes</tt>: two entries (index=a,size=b) and
+     * the <code>indexes</code> and <code>sizes</code>: two entries (index=a,size=b) and
      * (index=a,size=b') are equivalent to a single entry (index=a,size=b+b').
      *
      * @param indexes
@@ -2856,11 +2856,11 @@ class MethodWriter extends MethodVisitor {
      *            <i>first</i> byte of the <i>next</i> instruction).
      * @param sizes
      *            the number of bytes to be <i>added</i> to the above
-     *            instructions. More precisely, for each i < <tt>len</tt>,
-     *            <tt>sizes</tt>[i] bytes will be added at the end of the
-     *            instruction designated by <tt>indexes</tt>[i] or, if
-     *            <tt>sizes</tt>[i] is negative, the <i>last</i> |
-     *            <tt>sizes[i]</tt>| bytes of the instruction will be removed
+     *            instructions. More precisely, for each i < <code>len</code>,
+     *            <code>sizes</code>[i] bytes will be added at the end of the
+     *            instruction designated by <code>indexes</code>[i] or, if
+     *            <code>sizes</code>[i] is negative, the <i>last</i> |
+     *            <code>sizes[i]</code>| bytes of the instruction will be removed
      *            (the instruction size <i>must not</i> become negative or
      *            null).
      * @param begin
@@ -2894,11 +2894,11 @@ class MethodWriter extends MethodVisitor {
      *            <i>first</i> byte of the <i>next</i> instruction).
      * @param sizes
      *            the number of bytes to be <i>added</i> to the above
-     *            instructions. More precisely, for each i < <tt>len</tt>,
-     *            <tt>sizes</tt>[i] bytes will be added at the end of the
-     *            instruction designated by <tt>indexes</tt>[i] or, if
-     *            <tt>sizes</tt>[i] is negative, the <i>last</i> |
-     *            <tt>sizes[i]</tt>| bytes of the instruction will be removed
+     *            instructions. More precisely, for each i < <code>len</code>,
+     *            <code>sizes</code>[i] bytes will be added at the end of the
+     *            instruction designated by <code>indexes</code>[i] or, if
+     *            <code>sizes</code>[i] is negative, the <i>last</i> |
+     *            <code>sizes[i]</code>| bytes of the instruction will be removed
      *            (the instruction size <i>must not</i> become negative or
      *            null).
      * @param label

--- a/starts-core/src/main/java/edu/illinois/starts/asm/Type.java
+++ b/starts-core/src/main/java/edu/illinois/starts/asm/Type.java
@@ -43,47 +43,47 @@ import java.lang.reflect.Method;
 public class Type {
 
     /**
-     * The sort of the <tt>void</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>void</code> type. See {@link #getSort getSort}.
      */
     public static final int VOID = 0;
 
     /**
-     * The sort of the <tt>boolean</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>boolean</code> type. See {@link #getSort getSort}.
      */
     public static final int BOOLEAN = 1;
 
     /**
-     * The sort of the <tt>char</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>char</code> type. See {@link #getSort getSort}.
      */
     public static final int CHAR = 2;
 
     /**
-     * The sort of the <tt>byte</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>byte</code> type. See {@link #getSort getSort}.
      */
     public static final int BYTE = 3;
 
     /**
-     * The sort of the <tt>short</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>short</code> type. See {@link #getSort getSort}.
      */
     public static final int SHORT = 4;
 
     /**
-     * The sort of the <tt>int</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>int</code> type. See {@link #getSort getSort}.
      */
     public static final int INT = 5;
 
     /**
-     * The sort of the <tt>float</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>float</code> type. See {@link #getSort getSort}.
      */
     public static final int FLOAT = 6;
 
     /**
-     * The sort of the <tt>long</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>long</code> type. See {@link #getSort getSort}.
      */
     public static final int LONG = 7;
 
     /**
-     * The sort of the <tt>double</tt> type. See {@link #getSort getSort}.
+     * The sort of the <code>double</code> type. See {@link #getSort getSort}.
      */
     public static final int DOUBLE = 8;
 
@@ -103,55 +103,55 @@ public class Type {
     public static final int METHOD = 11;
 
     /**
-     * The <tt>void</tt> type.
+     * The <code>void</code> type.
      */
     public static final Type VOID_TYPE = new Type(VOID, null, ('V' << 24)
             | (5 << 16) | (0 << 8) | 0, 1);
 
     /**
-     * The <tt>boolean</tt> type.
+     * The <code>boolean</code> type.
      */
     public static final Type BOOLEAN_TYPE = new Type(BOOLEAN, null, ('Z' << 24)
             | (0 << 16) | (5 << 8) | 1, 1);
 
     /**
-     * The <tt>char</tt> type.
+     * The <code>char</code> type.
      */
     public static final Type CHAR_TYPE = new Type(CHAR, null, ('C' << 24)
             | (0 << 16) | (6 << 8) | 1, 1);
 
     /**
-     * The <tt>byte</tt> type.
+     * The <code>byte</code> type.
      */
     public static final Type BYTE_TYPE = new Type(BYTE, null, ('B' << 24)
             | (0 << 16) | (5 << 8) | 1, 1);
 
     /**
-     * The <tt>short</tt> type.
+     * The <code>short</code> type.
      */
     public static final Type SHORT_TYPE = new Type(SHORT, null, ('S' << 24)
             | (0 << 16) | (7 << 8) | 1, 1);
 
     /**
-     * The <tt>int</tt> type.
+     * The <code>int</code> type.
      */
     public static final Type INT_TYPE = new Type(INT, null, ('I' << 24)
             | (0 << 16) | (0 << 8) | 1, 1);
 
     /**
-     * The <tt>float</tt> type.
+     * The <code>float</code> type.
      */
     public static final Type FLOAT_TYPE = new Type(FLOAT, null, ('F' << 24)
             | (2 << 16) | (2 << 8) | 1, 1);
 
     /**
-     * The <tt>long</tt> type.
+     * The <code>long</code> type.
      */
     public static final Type LONG_TYPE = new Type(LONG, null, ('J' << 24)
             | (1 << 16) | (1 << 8) | 2, 1);
 
     /**
-     * The <tt>double</tt> type.
+     * The <code>double</code> type.
      */
     public static final Type DOUBLE_TYPE = new Type(DOUBLE, null, ('D' << 24)
             | (3 << 16) | (3 << 8) | 2, 1);
@@ -402,8 +402,8 @@ public class Type {
      * @return the size of the arguments of the method (plus one for the
      *         implicit this argument), argSize, and the size of its return
      *         value, retSize, packed into a single int i =
-     *         <tt>(argSize &lt;&lt; 2) | retSize</tt> (argSize is therefore equal to
-     *         <tt>i &gt;&gt; 2</tt>, and retSize to <tt>i &amp; 0x03</tt>).
+     *         <code>(argSize &lt;&lt; 2) | retSize</code> (argSize is therefore equal to
+     *         <code>i &gt;&gt; 2</code>, and retSize to <code>i &amp; 0x03</code>).
      */
     public static int getArgumentsAndReturnSizes(final String desc) {
         int n = 1;
@@ -608,9 +608,9 @@ public class Type {
      * @return the size of the arguments (plus one for the implicit this
      *         argument), argSize, and the size of the return value, retSize,
      *         packed into a single
-     *         int i = <tt>(argSize &lt;&lt; 2) | retSize</tt>
-     *         (argSize is therefore equal to <tt>i &gt;&gt; 2</tt>,
-     *         and retSize to <tt>i &amp; 0x03</tt>).
+     *         int i = <code>(argSize &lt;&lt; 2) | retSize</code>
+     *         (argSize is therefore equal to <code>i &gt;&gt; 2</code>,
+     *         and retSize to <code>i &amp; 0x03</code>).
      */
     public int getArgumentsAndReturnSizes() {
         return getArgumentsAndReturnSizes(getDescriptor());
@@ -801,8 +801,8 @@ public class Type {
      * Returns the size of values of this type. This method must not be used for
      * method types.
      *
-     * @return the size of values of this type, i.e., 2 for <tt>long</tt> and
-     *         <tt>double</tt>, 0 for <tt>void</tt> and 1 otherwise.
+     * @return the size of values of this type, i.e., 2 for <code>long</code> and
+     *         <code>double</code>, 0 for <code>void</code> and 1 otherwise.
      */
     public int getSize() {
         // the size is in byte 0 of 'off' for primitive types (buf == null)
@@ -818,8 +818,8 @@ public class Type {
      *            ISTORE, IALOAD, IASTORE, IADD, ISUB, IMUL, IDIV, IREM, INEG,
      *            ISHL, ISHR, IUSHR, IAND, IOR, IXOR and IRETURN.
      * @return an opcode that is similar to the given opcode, but adapted to
-     *         this Java type. For example, if this type is <tt>float</tt> and
-     *         <tt>opcode</tt> is IRETURN, this method returns FRETURN.
+     *         this Java type. For example, if this type is <code>float</code> and
+     *         <code>opcode</code> is IRETURN, this method returns FRETURN.
      */
     public int getOpcode(final int opcode) {
         if (opcode == Opcodes.IALOAD || opcode == Opcodes.IASTORE) {
@@ -842,7 +842,7 @@ public class Type {
      *
      * @param o
      *            the object to be compared to this type.
-     * @return <tt>true</tt> if the given object is equal to this type.
+     * @return <code>true</code> if the given object is equal to this type.
      */
     @Override
     public boolean equals(final Object o) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
-import com.sun.tools.jdeps.Main;
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.util.ChecksumUtil;
 import edu.illinois.starts.util.Logger;
@@ -29,6 +30,10 @@ import org.ekstazi.data.RegData;
  */
 public class RTSUtil implements StartsConstants {
     private static final Logger LOGGER = Logger.getGlobal();
+    /** Name of tools.jar in JDK */
+    private static final String TOOLS_JAR_NAME = "tools.jar";
+    /** Name of tools.jar on Mac in JDK */
+    private static final String CLASSES_JAR_NAME = "classes.jar";
 
     public static void saveForNextRun(String artifactsDir, DirectedGraph<String> graph,
                                       boolean printGraph, String graphFile) {
@@ -76,9 +81,54 @@ public class RTSUtil implements StartsConstants {
     public static Map<String, Set<String>> runJdeps(List<String> args) {
         StringWriter output = new StringWriter();
         LOGGER.log(Level.FINE, "JDEPS ARGS:" + args);
-        Main.run(args.toArray(new String[0]), new PrintWriter(output));
+
+        try {
+            File toolsJarFile = findToolsJar();
+            if (!toolsJarFile.exists()) {
+                // Java 9+, load jdeps through java.util.spi.ToolProvider
+                Class<?> toolProvider = ClassLoader.getSystemClassLoader().loadClass("java.util.spi.ToolProvider");
+                Object jdeps = toolProvider.getMethod("findFirst", String.class).invoke(null, "jdeps");
+                toolProvider.getMethod("run", PrintWriter.class, PrintWriter.class, String[].class)
+                        .invoke(jdeps, new PrintWriter(output), new PrintWriter(output), args.toArray(new String[0]));
+            } else {
+                // Java 8, load tools.jar
+                URLClassLoader loader = new URLClassLoader(new URL[] { toolsJarFile.toURI().toURL() },
+                        ClassLoader.getSystemClassLoader());
+                Class<?> jdepsMain = loader.loadClass("com.sun.tools.jdeps.Main");
+                jdepsMain.getMethod("run", String[].class, PrintWriter.class)
+                        .invoke(null, args.toArray(new String[0]), new PrintWriter(output));
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
         // jdeps can return an empty output when run on .jar files with no .class files
         return output.getBuffer().length() != 0 ? getDepsFromJdepsOutput(output) : new HashMap<String, Set<String>>();
+    }
+
+    private static File findToolsJar() {
+        String javaHome = System.getProperty("java.home");
+        File javaHomeFile = new File(javaHome);
+        File toolsJarFile = new File(javaHomeFile, "lib" + File.separator + TOOLS_JAR_NAME);
+
+        if (!toolsJarFile.exists()) {
+            toolsJarFile = new File(System.getenv("java_home"), "lib" + File.separator + TOOLS_JAR_NAME);
+        }
+
+        if (!toolsJarFile.exists() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "jre")) {
+            javaHomeFile = javaHomeFile.getParentFile();
+            toolsJarFile = new File(javaHomeFile, "lib" + File.separator + TOOLS_JAR_NAME);
+        }
+
+        if (!toolsJarFile.exists() && isMac() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "Home")) {
+            javaHomeFile = javaHomeFile.getParentFile();
+            toolsJarFile = new File(javaHomeFile, "Classes" + File.separator + CLASSES_JAR_NAME);
+        }
+
+        return toolsJarFile;
+    }
+
+    private static boolean isMac() {
+        return System.getProperty("os.name").toLowerCase().contains("mac");
     }
 
     public static Map<String, Set<String>> getDepsFromJdepsOutput(StringWriter jdepsOutput) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/RTSUtil.java
@@ -30,9 +30,9 @@ import org.ekstazi.data.RegData;
  */
 public class RTSUtil implements StartsConstants {
     private static final Logger LOGGER = Logger.getGlobal();
-    /** Name of tools.jar in JDK */
+    // Name of tools.jar in JDK
     private static final String TOOLS_JAR_NAME = "tools.jar";
-    /** Name of tools.jar on Mac in JDK */
+    // Name of tools.jar on Mac in JDK
     private static final String CLASSES_JAR_NAME = "classes.jar";
 
     public static void saveForNextRun(String artifactsDir, DirectedGraph<String> graph,

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -68,6 +68,8 @@ public final class AgentLoader implements StartsConstants {
     }
 
     private static Class<?> loadVirtualMachine(URL[] urls) throws Exception {
+        // Code copied from ekstazi:
+        // https://github.com/gliga/ekstazi/blob/6567da0534c20eeee802d2dfb8d216cbcbf6883c/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java#L88
         try {
             return ClassLoader.getSystemClassLoader().loadClass("com.sun.tools.attach.VirtualMachine");
         } catch (ClassNotFoundException ex) {

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -2,9 +2,10 @@ package edu.illinois.starts.maven;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.net.URL;
-
-import com.sun.tools.attach.VirtualMachine;
+import java.net.URLClassLoader;
 
 import edu.illinois.starts.constants.StartsConstants;
 
@@ -12,6 +13,9 @@ import edu.illinois.starts.constants.StartsConstants;
  * This class is duplicated from Ekstazi, with minor changes.
  */
 public final class AgentLoader implements StartsConstants {
+    private static final String TOOLS_JAR_NAME = "tools.jar";
+    private static final String CLASSES_JAR_NAME = "classes.jar";
+    private static final String LIB = "lib";
     private static final String AGENT_INIT = AgentLoader.class.getName() + " Initialized";
 
     public static boolean loadDynamicAgent() {
@@ -25,26 +29,81 @@ public final class AgentLoader implements StartsConstants {
             URL agentJarURLConnection = AbstractMojoInterceptor.extractJarURL(agentJarURL);
             return loadAgent(agentJarURLConnection);
         } catch (Exception ex) {
+            ex.printStackTrace();
             return false;
         }
     }
 
     public static boolean loadAgent(URL aju) throws Exception {
-        attachAgent(aju);
+        URL toolsJarFile = findToolsJar();
+
+        Class<?> vc = loadVirtualMachine(new URL[]{toolsJarFile});
+        if (vc == null) {
+            return false;
+        }
+
+        attachAgent(vc, aju);
         return true;
     }
 
-    private static void attachAgent(URL aju) throws Exception {
+    private static void attachAgent(Class<?> vc, URL aju) throws Exception {
         String pid = getPID();
         String agentAbsolutePath = new File(aju.toURI().getSchemeSpecificPart()).getAbsolutePath();
 
-        VirtualMachine vm = VirtualMachine.attach(pid);
-        vm.loadAgent(agentAbsolutePath);
-        vm.detach();
+        Object vm = getAttachMethod(vc).invoke(null, new Object[]{pid});
+        getLoadAgentMethod(vc).invoke(vm, new Object[]{agentAbsolutePath});
+        getDetachMethod(vc).invoke(vm);
+    }
+
+    private static Method getAttachMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
+        return vc.getMethod("attach", new Class<?>[]{String.class});
+    }
+
+    private static Method getLoadAgentMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
+        return vc.getMethod("loadAgent", new Class[]{String.class});
+    }
+
+    private static Method getDetachMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
+        return vc.getMethod("detach");
+    }
+
+    private static Class<?> loadVirtualMachine(URL[] urls) throws Exception {
+        try {
+            return ClassLoader.getSystemClassLoader().loadClass("com.sun.tools.attach.VirtualMachine");
+        } catch (ClassNotFoundException ex) {
+            URLClassLoader loader = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
+            return loader.loadClass("com.sun.tools.attach.VirtualMachine");
+        }
     }
 
     private static String getPID() {
         String vmName = ManagementFactory.getRuntimeMXBean().getName();
         return vmName.substring(0, vmName.indexOf("@"));
+    }
+
+    private static URL findToolsJar() throws MalformedURLException {
+        String javaHome = System.getProperty(JAVA_HOME);
+        File javaHomeFile = new File(javaHome);
+        File tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
+
+        if (!tjf.exists()) {
+            tjf = new File(System.getenv("java_home"), LIB + File.separator + TOOLS_JAR_NAME);
+        }
+
+        if (!tjf.exists() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "jre")) {
+            javaHomeFile = javaHomeFile.getParentFile();
+            tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
+        }
+
+        if (!tjf.exists() && isMac() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "Home")) {
+            javaHomeFile = javaHomeFile.getParentFile();
+            tjf = new File(javaHomeFile, "Classes" + File.separator + CLASSES_JAR_NAME);
+        }
+
+        return tjf.toURI().toURL();
+    }
+
+    private static boolean isMac() {
+        return System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0;
     }
 }

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -2,10 +2,9 @@ package edu.illinois.starts.maven;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
+
+import com.sun.tools.attach.VirtualMachine;
 
 import edu.illinois.starts.constants.StartsConstants;
 
@@ -13,9 +12,6 @@ import edu.illinois.starts.constants.StartsConstants;
  * This class is duplicated from Ekstazi, with minor changes.
  */
 public final class AgentLoader implements StartsConstants {
-    private static final String TOOLS_JAR_NAME = "tools.jar";
-    private static final String CLASSES_JAR_NAME = "classes.jar";
-    private static final String LIB = "lib";
     private static final String AGENT_INIT = AgentLoader.class.getName() + " Initialized";
 
     public static boolean loadDynamicAgent() {
@@ -34,74 +30,21 @@ public final class AgentLoader implements StartsConstants {
     }
 
     public static boolean loadAgent(URL aju) throws Exception {
-        URL toolsJarFile = findToolsJar();
-        if (toolsJarFile == null) {
-            return false;
-        }
-
-        Class<?> vc = loadVirtualMachine(new URL[]{toolsJarFile});
-        if (vc == null) {
-            return false;
-        }
-
-        attachAgent(vc, aju);
+        attachAgent(aju);
         return true;
     }
 
-    private static void attachAgent(Class<?> vc, URL aju) throws Exception {
+    private static void attachAgent(URL aju) throws Exception {
         String pid = getPID();
         String agentAbsolutePath = new File(aju.toURI().getSchemeSpecificPart()).getAbsolutePath();
 
-        Object vm = getAttachMethod(vc).invoke(null, new Object[]{pid});
-        getLoadAgentMethod(vc).invoke(vm, new Object[]{agentAbsolutePath});
-        getDetachMethod(vc).invoke(vm);
-    }
-
-    private static Method getAttachMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
-        return vc.getMethod("attach", new Class<?>[]{String.class});
-    }
-
-    private static Method getLoadAgentMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
-        return vc.getMethod("loadAgent", new Class[]{String.class});
-    }
-
-    private static Method getDetachMethod(Class<?> vc) throws SecurityException, NoSuchMethodException {
-        return vc.getMethod("detach");
-    }
-
-    private static Class<?> loadVirtualMachine(URL[] urls) throws Exception {
-        URLClassLoader loader = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
-        return loader.loadClass("com.sun.tools.attach.VirtualMachine");
+        VirtualMachine vm = VirtualMachine.attach(pid);
+        vm.loadAgent(agentAbsolutePath);
+        vm.detach();
     }
 
     private static String getPID() {
         String vmName = ManagementFactory.getRuntimeMXBean().getName();
         return vmName.substring(0, vmName.indexOf("@"));
-    }
-
-    private static URL findToolsJar() throws MalformedURLException {
-        String javaHome = System.getProperty(JAVA_HOME);
-        File javaHomeFile = new File(javaHome);
-        File tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
-
-        if (!tjf.exists()) {
-            tjf = new File(System.getenv("java_home"), LIB + File.separator + TOOLS_JAR_NAME);
-        }
-
-        if (!tjf.exists() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "jre")) {
-            javaHomeFile = javaHomeFile.getParentFile();
-            tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);
-        }
-
-        if (!tjf.exists() && isMac() && javaHomeFile.getAbsolutePath().endsWith(File.separator + "Home")) {
-            javaHomeFile = javaHomeFile.getParentFile();
-            tjf = new File(javaHomeFile, "Classes" + File.separator + CLASSES_JAR_NAME);
-        }
-
-        return tjf.toURI().toURL();
-    }
-
-    private static boolean isMac() {
-        return System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0;
     }
 }

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -40,9 +40,13 @@ public final class AgentLoader implements StartsConstants {
     }
 
     public static boolean loadAgent(URL aju) throws Exception {
-        URL toolsJarFile = findToolsJar().toURI().toURL();
+        File toolsJarFile = findToolsJar();
+        if (toolsJarFile == null) {  // TODO: maybe remove null check
+            return false;
+        }
+        URL toolsJarFileURL = toolsJarFile.toURI().toURL();
 
-        Class<?> vc = loadVirtualMachine(new URL[]{toolsJarFile});
+        Class<?> vc = loadVirtualMachine(new URL[]{toolsJarFileURL});
         if (vc == null) {
             return false;
         }
@@ -88,7 +92,7 @@ public final class AgentLoader implements StartsConstants {
         return vmName.substring(0, vmName.indexOf("@"));
     }
 
-    private static File findToolsJar() throws MalformedURLException {
+    private static File findToolsJar() {
         // Copied from ekstazi:
         // https://github.com/gliga/ekstazi/blob/6567da0534c20eeee802d2dfb8d216cbcbf6883c/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java#L209
         String javaHome = System.getProperty(JAVA_HOME);

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -1,11 +1,16 @@
 package edu.illinois.starts.maven;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.List;
+import java.util.Optional;
 
 import edu.illinois.starts.constants.StartsConstants;
 
@@ -35,7 +40,7 @@ public final class AgentLoader implements StartsConstants {
     }
 
     public static boolean loadAgent(URL aju) throws Exception {
-        URL toolsJarFile = findToolsJar();
+        URL toolsJarFile = findToolsJar().toURI().toURL();
 
         Class<?> vc = loadVirtualMachine(new URL[]{toolsJarFile});
         if (vc == null) {
@@ -83,7 +88,7 @@ public final class AgentLoader implements StartsConstants {
         return vmName.substring(0, vmName.indexOf("@"));
     }
 
-    private static URL findToolsJar() throws MalformedURLException {
+    private static File findToolsJar() throws MalformedURLException {
         // Copied from ekstazi:
         // https://github.com/gliga/ekstazi/blob/6567da0534c20eeee802d2dfb8d216cbcbf6883c/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java#L209
         String javaHome = System.getProperty(JAVA_HOME);
@@ -104,10 +109,43 @@ public final class AgentLoader implements StartsConstants {
             tjf = new File(javaHomeFile, "Classes" + File.separator + CLASSES_JAR_NAME);
         }
 
-        return tjf.toURI().toURL();
+        return tjf;
     }
 
     private static boolean isMac() {
         return System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0;
+    }
+
+    public static StringWriter loadAndRunJdeps(List<String> args) {
+        StringWriter output = new StringWriter();
+        try {
+            File toolsJarFile = findToolsJar();
+            if (!toolsJarFile.exists()) {
+                // Java 9+, load jdeps through java.util.spi.ToolProvider
+                Class<?> toolProvider = ClassLoader.getSystemClassLoader().loadClass("java.util.spi.ToolProvider");
+                Object jdeps = toolProvider.getMethod("findFirst", String.class).invoke(null, "jdeps");
+                jdeps = Optional.class.getMethod("get").invoke(jdeps);
+                toolProvider.getMethod("run", PrintWriter.class, PrintWriter.class, String[].class)
+                        .invoke(jdeps, new PrintWriter(output), new PrintWriter(output), args.toArray(new String[0]));
+            } else {
+                // Java 8, load tools.jar
+                URLClassLoader loader = new URLClassLoader(new URL[] { toolsJarFile.toURI().toURL() },
+                        ClassLoader.getSystemClassLoader());
+                Class<?> jdepsMain = loader.loadClass("com.sun.tools.jdeps.Main");
+                jdepsMain.getMethod("run", String[].class, PrintWriter.class)
+                        .invoke(null, args.toArray(new String[0]), new PrintWriter(output));
+            }
+        } catch (MalformedURLException malformedURLException) {
+            malformedURLException.printStackTrace();
+        } catch (ClassNotFoundException classNotFoundException) {
+            classNotFoundException.printStackTrace();
+        } catch (InvocationTargetException invocationTargetException) {
+            invocationTargetException.printStackTrace();
+        } catch (IllegalAccessException illegalAccessException) {
+            illegalAccessException.printStackTrace();
+        } catch (NoSuchMethodException noSuchMethodException) {
+            noSuchMethodException.printStackTrace();
+        }
+        return output;
     }
 }

--- a/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
+++ b/starts-core/src/main/java/edu/illinois/starts/maven/AgentLoader.java
@@ -84,6 +84,8 @@ public final class AgentLoader implements StartsConstants {
     }
 
     private static URL findToolsJar() throws MalformedURLException {
+        // Copied from ekstazi:
+        // https://github.com/gliga/ekstazi/blob/6567da0534c20eeee802d2dfb8d216cbcbf6883c/org.ekstazi.core/src/main/java/org/ekstazi/agent/AgentLoader.java#L209
         String javaHome = System.getProperty(JAVA_HOME);
         File javaHomeFile = new File(javaHome);
         File tjf = new File(javaHomeFile, LIB + File.separator + TOOLS_JAR_NAME);

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -33,9 +33,6 @@
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-       <configuration>
-         <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
-       </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -65,7 +62,6 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
           <addTestClassPath>true</addTestClassPath>
           <debug>false</debug>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -33,6 +33,9 @@
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+       <configuration>
+         <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+       </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -62,6 +65,7 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
+          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
           <addTestClassPath>true</addTestClassPath>
           <debug>false</debug>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -30,6 +30,14 @@
 
   <build>
     <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-compiler-plugin</artifactId>
+      <configuration>
+        <source>8</source>
+        <target>8</target>
+      </configuration>
+    </plugin>
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -31,6 +31,7 @@
   <build>
     <plugins>
     <plugin>
+      <!-- Using compiler version 8 to allow method reference -->
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-compiler-plugin</artifactId>
       <configuration>

--- a/starts-plugin/src/it/parent-pom.xml
+++ b/starts-plugin/src/it/parent-pom.xml
@@ -15,6 +15,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <it.version>1.0-SNAPSHOT</it.version>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <build>
@@ -32,11 +34,17 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
+        <configuration>
+          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/starts-plugin/src/it/parent-pom.xml
+++ b/starts-plugin/src/it/parent-pom.xml
@@ -15,8 +15,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <it.version>1.0-SNAPSHOT</it.version>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <build>
@@ -34,17 +34,11 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
-        <configuration>
-          <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
 - Removed the dependency of `tools.jar`, which was deprecated since Java 9
 - Instead, load `jdeps` and `com.sun.tools.attach.VirtualMachine` dynamically via reflections.
 - Add Github actions CI for multiple Java versions.
 - Upgrade Jacoco versions, so we won't get `NoSuchFieldException: $jacocoAccess`
 - Upgrade Maven compiler source and target for compatibility with higher Java versions.
 - Add config `-Djdk.attach.allowAttachSelf=true`, which became default to false since Java 9.
 - Use `<code>` tag rather than `<tt>` as `<tt>` is deprecated
   - was getting errors like `/Users/tianxing/Desktop/starts/starts-core/src/main/java/edu/illinois/starts/asm/MethodVisitor.java:35: error: tag not supported in the generated HTML version: tt` on Java 11.