### PR TITLE
Optimize ZLC file format

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: Report coverage
+
+on:
+  push:
+    branches:
+      - '**'  # any branch
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+
+      - name: Build with Maven
+        run: mvn -B verify --file pom.xml
+
+      - name: Merge coverage
+        run: mvn jacoco:merge@merge-id -pl starts-core
+
+      - name: Report
+        run: mvn jacoco:report@report-id -pl starts-core
+
+      - name: Generate JaCoCo Badge
+        id: jacoco
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: starts-core/target/site/jacoco-merged/jacoco.csv
+          generate-branches-badge: true
+
+      - name: Log coverage percentage
+        run: |
+          echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
+          echo "branch coverage = ${{ steps.jacoco.outputs.branches }}"
+
+#  Getting: RequestError [HttpError]: Resource not accessible by integration
+#      - name: Add comment to PR
+#        uses: actions/github-script@v4
+#        if: ${{ github.event_name == 'pull_request' }}
+#        with:
+#          github-token: ${{secrets.GITHUB_TOKEN}}
+#          script: |
+#            github.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: 'Statement coverage = ${{ steps.jacoco.outputs.coverage }}\n\nBranch coverage = ${{ steps.jacoco.outputs.branches }}'
+#            })

--- a/starts-core/pom.xml
+++ b/starts-core/pom.xml
@@ -47,5 +47,55 @@
             </configuration>
         </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.version}</version>
+          <executions>
+            <execution>
+              <id>report-id</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <dataFile>
+                  ${project.build.directory}/jacoco-merged.exec
+                </dataFile>
+                <excludes>
+                  <exclude>edu/illinois/starts/asm/**</exclude>
+                </excludes>
+                <outputDirectory>
+                  ${project.reporting.outputDirectory}/jacoco-merged
+                </outputDirectory>
+              </configuration>
+            </execution>
+            <execution>
+              <id>merge-id</id>
+              <goals>
+                <goal>merge</goal>
+              </goals>
+              <configuration>
+                <fileSets>
+                  <fileSet>
+                    <directory>
+                      ${project.basedir}/../
+                    </directory>
+                    <includes>
+                      <include>starts-core/target/jacoco.exec</include>
+                      <include>starts-plugin/target/jacoco-it.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>
+                  ${project.build.directory}/jacoco-merged.exec
+                </destFile>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCData.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCData.java
@@ -7,6 +7,7 @@ package edu.illinois.starts.data;
 import static java.lang.String.join;
 
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,33 +21,35 @@ public class ZLCData implements StartsConstants {
     private ZLCFormat format;
     private URL url;
     private String checksum;
-    private Set<Pair<String, Integer>> tests;
+    private Set<String> testsStr;
+    private Set<Integer> testsIdx;
 
-    public ZLCData(URL url, String checksum, Set<Pair<String, Integer>> tests, ZLCFormat format) {
+    public ZLCData(URL url, String checksum, ZLCFormat format, Set<String> testsStr, Set<Integer> testsIdx) {
         this.format = format;
         this.url = url;
         this.checksum = checksum;
-        this.tests = tests;
+        this.testsStr = testsStr;
+        this.testsIdx = testsIdx;
     }
 
     @Override
     public String toString() {
         //we track dependencies that are not reached by any test because of *
         String data;
-        if (tests.isEmpty()) {
-            data = join(WHITE_SPACE, url.toExternalForm(), checksum);
-            return data;
-        }
         switch (format) {
             case INDEXED:
-                data = join(WHITE_SPACE, url.toExternalForm(), checksum, toCSVInt(
-                        tests.stream().map(Pair::getValue).collect(Collectors.toSet())
-                ));
+                if (testsIdx.isEmpty()) {
+                    data = join(WHITE_SPACE, url.toExternalForm(), checksum);
+                } else {
+                    data = join(WHITE_SPACE, url.toExternalForm(), checksum, toCSVInt(testsIdx));
+                }
                 break;
             case PLAIN_TEXT:
-                data = join(WHITE_SPACE, url.toExternalForm(), checksum, toCSVStr(
-                        tests.stream().map(Pair::getKey).collect(Collectors.toSet())
-                ));
+                if (testsStr.isEmpty()) {
+                    data = join(WHITE_SPACE, url.toExternalForm(), checksum);
+                } else {
+                    data = join(WHITE_SPACE, url.toExternalForm(), checksum, toCSVStr(testsStr));
+                }
                 break;
             default:
                 throw new RuntimeException("Unexpected ZLCFormat");
@@ -77,9 +80,5 @@ public class ZLCData implements StartsConstants {
             return false;
         }
         return checksum.equals(zlcData.checksum);
-    }
-
-    public void setTests(Set<Pair<String, Integer>> tests) {
-        this.tests = tests;
     }
 }

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCData.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCData.java
@@ -18,9 +18,9 @@ import edu.illinois.starts.constants.StartsConstants;
 public class ZLCData implements StartsConstants {
     private URL url;
     private String checksum;
-    private Set<String> tests;
+    private Set<Integer> tests;
 
-    public ZLCData(URL url, String checksum, Set<String> tests) {
+    public ZLCData(URL url, String checksum, Set<Integer> tests) {
         this.url = url;
         this.checksum = checksum;
         this.tests = tests;
@@ -38,8 +38,8 @@ public class ZLCData implements StartsConstants {
         return data;
     }
 
-    private String toCSV(Set<String> tests) {
-        return tests.stream().collect(Collectors.joining(COMMA));
+    private static String toCSV(Set<Integer> tests) {
+        return tests.stream().map(String::valueOf).collect(Collectors.joining(COMMA));
     }
 
     @Override
@@ -59,7 +59,7 @@ public class ZLCData implements StartsConstants {
         return checksum.equals(zlcData.checksum);
     }
 
-    public void setTests(Set<String> tests) {
+    public void setTests(Set<Integer> tests) {
         this.tests = tests;
     }
 }

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCFile.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCFile.java
@@ -1,0 +1,28 @@
+package edu.illinois.starts.data;
+
+import java.util.List;
+
+/**
+ * This class creates object that represents the entire .zlc file.
+ */
+public class ZLCFile {
+    private List<String> tests;
+    private List<ZLCData> zlcData;
+
+    public ZLCFile(List<String> tests, List<ZLCData> zlcData) {
+        this.tests = tests;
+        this.zlcData = zlcData;
+    }
+
+    public int getTestsCount() {
+        return tests.size();
+    }
+
+    public List<String> getTests() {
+        return tests;
+    }
+
+    public List<ZLCData> getZlcData() {
+        return zlcData;
+    }
+}

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCFile.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCFile.java
@@ -6,12 +6,18 @@ import java.util.List;
  * This class creates object that represents the entire .zlc file.
  */
 public class ZLCFile {
+    private ZLCFormat format;
     private List<String> tests;
     private List<ZLCData> zlcData;
 
-    public ZLCFile(List<String> tests, List<ZLCData> zlcData) {
+    public ZLCFile(List<String> tests, List<ZLCData> zlcData, ZLCFormat format) {
         this.tests = tests;
         this.zlcData = zlcData;
+        this.format = format;
+    }
+
+    public ZLCFormat getFormat() {
+        return format;
     }
 
     public int getTestsCount() {

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCFileContent.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCFileContent.java
@@ -5,12 +5,12 @@ import java.util.List;
 /**
  * This class creates object that represents the entire .zlc file.
  */
-public class ZLCFile {
+public class ZLCFileContent {
     private ZLCFormat format;
     private List<String> tests;
     private List<ZLCData> zlcData;
 
-    public ZLCFile(List<String> tests, List<ZLCData> zlcData, ZLCFormat format) {
+    public ZLCFileContent(List<String> tests, List<ZLCData> zlcData, ZLCFormat format) {
         this.tests = tests;
         this.zlcData = zlcData;
         this.format = format;

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCFormat.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCFormat.java
@@ -1,7 +1,7 @@
 package edu.illinois.starts.data;
 
 public enum ZLCFormat {
-    PLAIN_TEXT,
-    INDEXED,
+    PLAIN_TEXT,  // store full URLs of tests
+    INDEXED,  // store indices of tests
     ;
 }

--- a/starts-core/src/main/java/edu/illinois/starts/data/ZLCFormat.java
+++ b/starts-core/src/main/java/edu/illinois/starts/data/ZLCFormat.java
@@ -1,0 +1,7 @@
+package edu.illinois.starts.data;
+
+public enum ZLCFormat {
+    PLAIN_TEXT,
+    INDEXED,
+    ;
+}

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.data.ZLCData;
-import edu.illinois.starts.data.ZLCFile;
+import edu.illinois.starts.data.ZLCFileContent;
 import edu.illinois.starts.data.ZLCFormat;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
@@ -59,21 +59,21 @@ public class Writer implements StartsConstants {
         }
     }
 
-    public static void writeToFile(ZLCFile zlcFile, String filename, String artifactsDir) {
+    public static void writeToFile(ZLCFileContent zlcFileContent, String filename, String artifactsDir) {
         String outFilename = artifactsDir + File.separator + filename;
-        writeToFile(zlcFile, outFilename);
+        writeToFile(zlcFileContent, outFilename);
     }
 
-    public static void writeToFile(ZLCFile zlcFile, String filename) {
+    public static void writeToFile(ZLCFileContent zlcFileContent, String filename) {
         try (BufferedWriter writer = getWriter(filename)) {
-            writer.write(zlcFile.getFormat() + System.lineSeparator());
-            if (zlcFile.getFormat() == ZLCFormat.INDEXED) {
-                writer.write(zlcFile.getTestsCount() + System.lineSeparator());
-                for (String test: zlcFile.getTests()) {
+            writer.write(zlcFileContent.getFormat() + System.lineSeparator());
+            if (zlcFileContent.getFormat() == ZLCFormat.INDEXED) {
+                writer.write(zlcFileContent.getTestsCount() + System.lineSeparator());
+                for (String test: zlcFileContent.getTests()) {
                     writer.write(test + System.lineSeparator());
                 }
             }
-            for (ZLCData zlcData: zlcFile.getZlcData()) {
+            for (ZLCData zlcData: zlcFileContent.getZlcData()) {
                 writer.write(zlcData + System.lineSeparator());
             }
         } catch (IOException ioe) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.data.ZLCData;
 import edu.illinois.starts.data.ZLCFile;
+import edu.illinois.starts.data.ZLCFormat;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
 import edu.illinois.yasgl.DirectedGraph;
@@ -65,9 +66,12 @@ public class Writer implements StartsConstants {
 
     public static void writeToFile(ZLCFile zlcFile, String filename) {
         try (BufferedWriter writer = getWriter(filename)) {
-            writer.write(zlcFile.getTestsCount() + System.lineSeparator());
-            for (String test: zlcFile.getTests()) {
-                writer.write(test + System.lineSeparator());
+            writer.write(zlcFile.getFormat() + System.lineSeparator());
+            if (zlcFile.getFormat() == ZLCFormat.INDEXED) {
+                writer.write(zlcFile.getTestsCount() + System.lineSeparator());
+                for (String test: zlcFile.getTests()) {
+                    writer.write(test + System.lineSeparator());
+                }
             }
             for (ZLCData zlcData: zlcFile.getZlcData()) {
                 writer.write(zlcData + System.lineSeparator());

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Writer.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import edu.illinois.starts.constants.StartsConstants;
+import edu.illinois.starts.data.ZLCData;
+import edu.illinois.starts.data.ZLCFile;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
 import edu.illinois.yasgl.DirectedGraph;
@@ -50,6 +52,25 @@ public class Writer implements StartsConstants {
             }
             for (Object elem : col) {
                 writer.write(elem + System.lineSeparator());
+            }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    public static void writeToFile(ZLCFile zlcFile, String filename, String artifactsDir) {
+        String outFilename = artifactsDir + File.separator + filename;
+        writeToFile(zlcFile, outFilename);
+    }
+
+    public static void writeToFile(ZLCFile zlcFile, String filename) {
+        try (BufferedWriter writer = getWriter(filename)) {
+            writer.write(zlcFile.getTestsCount() + System.lineSeparator());
+            for (String test: zlcFile.getTests()) {
+                writer.write(test + System.lineSeparator());
+            }
+            for (ZLCData zlcData: zlcFile.getZlcData()) {
+                writer.write(zlcData + System.lineSeparator());
             }
         } catch (IOException ioe) {
             ioe.printStackTrace();

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.data.ZLCData;
-import edu.illinois.starts.data.ZLCFile;
+import edu.illinois.starts.data.ZLCFileContent;
 import edu.illinois.starts.data.ZLCFormat;
 import edu.illinois.starts.util.ChecksumUtil;
 import edu.illinois.starts.util.Logger;
@@ -87,13 +87,13 @@ public class ZLCHelper implements StartsConstants {
         // TODO: Optimize this by only recomputing the checksum+tests for changed classes and newly added tests
         long start = System.currentTimeMillis();
         LOGGER.log(Level.FINE, "ZLC format: " + format.toString());
-        ZLCFile zlc = createZLCData(testDeps, loader, useThirdParty, format);
+        ZLCFileContent zlc = createZLCData(testDeps, loader, useThirdParty, format);
         Writer.writeToFile(zlc, zlcFile, artifactsDir);
         long end = System.currentTimeMillis();
         LOGGER.log(Level.FINE, "[PROFILE] updateForNextRun(updateZLCFile): " + Writer.millsToSeconds(end - start));
     }
 
-    public static ZLCFile createZLCData(
+    public static ZLCFileContent createZLCData(
             Map<String, Set<String>> testDeps,
             ClassLoader loader,
             boolean useJars,
@@ -149,7 +149,7 @@ public class ZLCHelper implements StartsConstants {
         }
         long end = System.currentTimeMillis();
         LOGGER.log(Level.FINEST, "[TIME]CREATING ZLC FILE: " + (end - start) + MILLISECOND);
-        return new ZLCFile(testList, zlcData, format);
+        return new ZLCFileContent(testList, zlcData, format);
     }
 
     public static Pair<Set<String>, Set<String>> getChangedData(String artifactsDir, boolean cleanBytes) {

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import edu.illinois.starts.constants.StartsConstants;
 import edu.illinois.starts.data.ZLCData;
 import edu.illinois.starts.data.ZLCFile;
+import edu.illinois.starts.data.ZLCFormat;
 import edu.illinois.starts.util.ChecksumUtil;
 import edu.illinois.starts.util.Logger;
 import edu.illinois.starts.util.Pair;
@@ -81,16 +82,23 @@ public class ZLCHelper implements StartsConstants {
 //    }
 
     public static void updateZLCFile(Map<String, Set<String>> testDeps, ClassLoader loader,
-                                     String artifactsDir, Set<String> unreached, boolean useThirdParty) {
+                                     String artifactsDir, Set<String> unreached, boolean useThirdParty,
+                                     ZLCFormat format) {
         // TODO: Optimize this by only recomputing the checksum+tests for changed classes and newly added tests
         long start = System.currentTimeMillis();
-        ZLCFile zlc = createZLCData(testDeps, loader, useThirdParty);
+        LOGGER.log(Level.FINE, "ZLC format: " + format.toString());
+        ZLCFile zlc = createZLCData(testDeps, loader, useThirdParty, format);
         Writer.writeToFile(zlc, zlcFile, artifactsDir);
         long end = System.currentTimeMillis();
         LOGGER.log(Level.FINE, "[PROFILE] updateForNextRun(updateZLCFile): " + Writer.millsToSeconds(end - start));
     }
 
-    public static ZLCFile createZLCData(Map<String, Set<String>> testDeps, ClassLoader loader, boolean useJars) {
+    public static ZLCFile createZLCData(
+            Map<String, Set<String>> testDeps,
+            ClassLoader loader,
+            boolean useJars,
+            ZLCFormat format
+    ) {
         long start = System.currentTimeMillis();
         List<ZLCData> zlcData = new ArrayList<>();
         Set<String> deps = new HashSet<>();
@@ -116,17 +124,17 @@ public class ZLCHelper implements StartsConstants {
                 continue;
             }
             String checksum = checksumUtil.computeSingleCheckSum(url);
-            Set<Integer> tests = new HashSet<>();
+            Set<Pair<String, Integer>> tests = new HashSet<>();
             for (int i = 0; i < testList.size(); i++) {
                 if (testDeps.get(testList.get(i)).contains(dep)) {
-                    tests.add(i);
+                    tests.add(new Pair<>(testList.get(i), i));
                 }
             }
-            zlcData.add(new ZLCData(url, checksum, tests));
+            zlcData.add(new ZLCData(url, checksum, tests, format));
         }
         long end = System.currentTimeMillis();
         LOGGER.log(Level.FINEST, "[TIME]CREATING ZLC FILE: " + (end - start) + MILLISECOND);
-        return new ZLCFile(testList, zlcData);
+        return new ZLCFile(testList, zlcData, format);
     }
 
     public static Pair<Set<String>, Set<String>> getChangedData(String artifactsDir, boolean cleanBytes) {
@@ -153,13 +161,23 @@ public class ZLCHelper implements StartsConstants {
                 zlcLines.remove(0);
             }
 
-            int testsCount = 0;
-            try {
-                testsCount = Integer.parseInt(zlcLines.get(0));
-            } catch (NumberFormatException nfe) {
-                nfe.printStackTrace();
+            ZLCFormat format = ZLCFormat.PLAIN_TEXT;  // default to plain text
+            if (zlcLines.get(0).equals(ZLCFormat.PLAIN_TEXT.toString())) {
+                format = ZLCFormat.PLAIN_TEXT;
+                zlcLines.remove(0);
+            } else if (zlcLines.get(0).equals(ZLCFormat.INDEXED.toString())) {
+                format = ZLCFormat.INDEXED;
+                zlcLines.remove(0);
             }
 
+            int testsCount = 0;
+            if (format == ZLCFormat.INDEXED) {
+                try {
+                    testsCount = Integer.parseInt(zlcLines.get(0));
+                } catch (NumberFormatException nfe) {
+                    nfe.printStackTrace();
+                }
+            }
             ArrayList<String> testsList = new ArrayList<>(zlcLines.subList(1, testsCount + 1));
 
             for (int i = testsCount + 1; i < zlcLines.size(); i++) {
@@ -167,8 +185,13 @@ public class ZLCHelper implements StartsConstants {
                 String[] parts = line.split(space);
                 String stringURL = parts[0];
                 String oldCheckSum = parts[1];
-                Set<Integer> testsIdx = parts.length == 3 ? fromCSVToInt(parts[2]) : new HashSet<Integer>();
-                Set<String> tests = testsIdx.stream().map(testsList::get).collect(Collectors.toSet());
+                Set<String> tests;
+                if (format == ZLCFormat.INDEXED) {
+                    Set<Integer> testsIdx = parts.length == 3 ? fromCSVToInt(parts[2]) : new HashSet<>();
+                    tests = testsIdx.stream().map(testsList::get).collect(Collectors.toSet());
+                } else {
+                    tests = parts.length == 3 ? fromCSV(parts[2]) : new HashSet<>();
+                }
                 nonAffected.addAll(tests);
                 URL url = new URL(stringURL);
                 String newCheckSum = checksumUtil.computeSingleCheckSum(url);
@@ -181,8 +204,6 @@ public class ZLCHelper implements StartsConstants {
                     LOGGER.log(Level.FINEST, "Ignoring: " + url);
                     continue;
                 }
-                ZLCData data = new ZLCData(url, newCheckSum, testsIdx);
-                zlcDataMap.put(stringURL, data);
             }
         } catch (IOException ioe) {
             ioe.printStackTrace();

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelper.java
@@ -124,13 +124,28 @@ public class ZLCHelper implements StartsConstants {
                 continue;
             }
             String checksum = checksumUtil.computeSingleCheckSum(url);
-            Set<Pair<String, Integer>> tests = new HashSet<>();
-            for (int i = 0; i < testList.size(); i++) {
-                if (testDeps.get(testList.get(i)).contains(dep)) {
-                    tests.add(new Pair<>(testList.get(i), i));
-                }
+            switch (format) {
+                case PLAIN_TEXT:
+                    Set<String> testsStr = new HashSet<>();
+                    for (String test: testDeps.keySet()) {
+                        if (testDeps.get(test).contains(dep)) {
+                            testsStr.add(test);
+                        }
+                    }
+                    zlcData.add(new ZLCData(url, checksum, format, testsStr, null));
+                    break;
+                case INDEXED:
+                    Set<Integer> testsIdx = new HashSet<>();
+                    for (int i = 0; i < testList.size(); i++) {
+                        if (testDeps.get(testList.get(i)).contains(dep)) {
+                            testsIdx.add(i);
+                        }
+                    }
+                    zlcData.add(new ZLCData(url, checksum, format, null, testsIdx));
+                    break;
+                default:
+                    throw new RuntimeException("Unexpected ZLCFormat");
             }
-            zlcData.add(new ZLCData(url, checksum, tests, format));
         }
         long end = System.currentTimeMillis();
         LOGGER.log(Level.FINEST, "[TIME]CREATING ZLC FILE: " + (end - start) + MILLISECOND);

--- a/starts-plugin/pom.xml
+++ b/starts-plugin/pom.xml
@@ -95,6 +95,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <id>pre-integration-test-execution</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+              <propertyName>invoker.mavenOpts</propertyName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/starts-plugin/src/it/multilevel-interfaces-it/pom.xml
+++ b/starts-plugin/src/it/multilevel-interfaces-it/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>starts.plugin.it</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multilevel-interfaces-it</artifactId>
+  <description>This integration test checks that the tests selected are only those
+    that reach a changed class or it's subclasses, but neither tests of
+    unrelated siblings nor superclasses.</description>
+</project>

--- a/starts-plugin/src/it/multilevel-interfaces-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-interfaces-it/setup.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.SetupUtil;
+
+setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+file = new File(basedir, "src/main/java/inter/BaseB.java");
+setupUtil.replaceAllInFile(file, "List", "ArrayList")

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/BaseA.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/BaseA.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.List;
+
+public interface BaseA {
+    public List<String> toStringsBaseA();
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/BaseB.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/BaseB.java
@@ -1,0 +1,7 @@
+package inter;
+
+import java.util.List;
+
+public interface BaseB {
+    public List<String> toStringsBaseB();
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/Child.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/Child.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Child implements BaseA, BaseB {
+    @Override
+    public ArrayList<String> toStringsBaseA() {
+        return new ArrayList<>(Arrays.asList("BaseA", "child"));
+    }
+
+    @Override
+    public ArrayList<String> toStringsBaseB() {
+        return new ArrayList<>(Arrays.asList("BaseB", "child"));
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/GrandChild.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/GrandChild.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class GrandChild extends Child {
+    @Override
+    public ArrayList<String> toStringsBaseA(){
+        return new ArrayList<>(Arrays.asList("BaseA", "GrandChild"));
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/Sibling.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/main/java/inter/Sibling.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Sibling implements BaseA {
+
+    @Override
+    public ArrayList<String> toStringsBaseA() {
+        return new ArrayList<>(Arrays.asList("sibling"));
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/ChildTest.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/ChildTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import static org.junit.Assert.assertEquals;
+
+public class ChildTest {
+    @Test
+    public void test() {
+        assertEquals("1", new ArrayList<>(Arrays.asList("BaseA", "child")), new Child().toStringsBaseA());
+        assertEquals("2", new ArrayList<>(Arrays.asList("BaseB", "child")), new Child().toStringsBaseB());
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/GrandChildTest.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/GrandChildTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class GrandChildTest {
+    @Test
+    public void test() {
+        assertEquals("1", new ArrayList<>(Arrays.asList("BaseA", "GrandChild")), new GrandChild().toStringsBaseA());
+        assertEquals("2", new ArrayList<>(Arrays.asList("BaseB", "child")), new GrandChild().toStringsBaseB());
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/SiblingTest.java
+++ b/starts-plugin/src/it/multilevel-interfaces-it/src/test/java/inter/SiblingTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class SiblingTest {
+    @Test
+    public void test() {
+        assertEquals("1", new ArrayList<>(Arrays.asList("sibling")), new Sibling().toStringsBaseA());
+    }
+}

--- a/starts-plugin/src/it/multilevel-interfaces-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-interfaces-it/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.VerifyUtil;
+
+firstRun = new File(basedir, "first-run.txt");
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+
+if (!firstRun.exists()) {
+    firstRun.createNewFile();
+    verifyUtil.assertCorrectlyAffected("3");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertContains("Running inter.SiblingTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+} else {
+    verifyUtil.assertCorrectlyAffected("2");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertNotContains("Running inter.SiblingTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+    verifyUtil.deleteFile(firstRun);
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/pom.xml
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>starts.plugin.it</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multilevel-no-parents-or-siblings-it</artifactId>
+  <description>This integration test checks that the tests selected are only those
+    that reach a changed class or it's subclasses, but neither tests of
+    unrelated siblings nor superclasses.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>touch</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>starts</goal>
+            </goals>
+            <configuration>
+              <depFormat>CLZ</depFormat>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/setup.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.SetupUtil;
+
+setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+file = new File(basedir, "src/main/java/inter/Child.java");
+setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Base.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Base.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Base {
+    protected LinkedHashSet output;
+
+    public Base() {
+        super();
+        output = new LinkedHashSet();
+    }
+
+    public void add(int a) {
+        output.add(a);
+    }
+
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Child.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Child.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.Set;
+
+public class Child extends Base {
+    @Override
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/GrandChild.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/GrandChild.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class GrandChild extends Child {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Sibling.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/main/java/inter/Sibling.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class Sibling extends Base {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/BaseTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/BaseTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class BaseTest {
+    @Test
+    public void test() {
+        Base base = new Base();
+        base.add(1);
+        base.add(2);
+        base.add(3);
+        Set<Integer> out = base.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/ChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/ChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class ChildTest {
+    @Test
+    public void test() {
+        Child son = new Child();
+        son.add(1);
+        son.add(2);
+        son.add(3);
+        Set<Integer> out = son.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/GrandChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/GrandChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class GrandChildTest {
+    @Test
+    public void test() {
+        GrandChild grand = new GrandChild();
+        grand.add(1);
+        grand.add(2);
+        grand.add(3);
+        Set<Integer> out = grand.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/SiblingTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/src/test/java/inter/SiblingTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class SiblingTest {
+    @Test
+    public void test() {
+        Sibling cousin = new Sibling();
+        cousin.add(1);
+        cousin.add(2);
+        cousin.add(3);
+        Set<Integer> out = cousin.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-clz-it/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.VerifyUtil;
+
+firstRun = new File(basedir, "first-run.txt");
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+
+if (!firstRun.exists()) {
+    firstRun.createNewFile();
+    verifyUtil.assertCorrectlyAffected("4");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertContains("Running inter.SiblingTest");
+    verifyUtil.assertContains("Running inter.BaseTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+} else {
+    verifyUtil.assertCorrectlyAffected("2");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertNotContains("Running inter.SiblingTest");
+    verifyUtil.assertNotContains("Running inter.BaseTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+    verifyUtil.deleteFile(firstRun);
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/pom.xml
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>starts.plugin.it</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multilevel-no-parents-or-siblings-it</artifactId>
+  <description>This integration test checks that the tests selected are only those
+    that reach a changed class or it's subclasses, but neither tests of
+    unrelated siblings nor superclasses.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <zlcFormat>INDEXED</zlcFormat>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/setup.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.SetupUtil;
+
+setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+file = new File(basedir, "src/main/java/inter/Child.java");
+setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Base.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Base.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Base {
+    protected LinkedHashSet output;
+
+    public Base() {
+        super();
+        output = new LinkedHashSet();
+    }
+
+    public void add(int a) {
+        output.add(a);
+    }
+
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Child.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Child.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.Set;
+
+public class Child extends Base {
+    @Override
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/GrandChild.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/GrandChild.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class GrandChild extends Child {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Sibling.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/main/java/inter/Sibling.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class Sibling extends Base {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/BaseTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/BaseTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class BaseTest {
+    @Test
+    public void test() {
+        Base base = new Base();
+        base.add(1);
+        base.add(2);
+        base.add(3);
+        Set<Integer> out = base.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/ChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/ChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class ChildTest {
+    @Test
+    public void test() {
+        Child son = new Child();
+        son.add(1);
+        son.add(2);
+        son.add(3);
+        Set<Integer> out = son.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/GrandChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/GrandChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class GrandChildTest {
+    @Test
+    public void test() {
+        GrandChild grand = new GrandChild();
+        grand.add(1);
+        grand.add(2);
+        grand.add(3);
+        Set<Integer> out = grand.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/SiblingTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/src/test/java/inter/SiblingTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class SiblingTest {
+    @Test
+    public void test() {
+        Sibling cousin = new Sibling();
+        cousin.add(1);
+        cousin.add(2);
+        cousin.add(3);
+        Set<Integer> out = cousin.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-indexedZLC-it/verify.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.VerifyUtil;
+
+firstRun = new File(basedir, "first-run.txt");
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+
+if (!firstRun.exists()) {
+    firstRun.createNewFile();
+    verifyUtil.assertCorrectlyAffected("4");
+} else {
+    verifyUtil.assertCorrectlyAffected("2");
+    verifyUtil.deleteFile(firstRun);
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/pom.xml
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>starts.plugin.it</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multilevel-no-parents-or-siblings-it</artifactId>
+  <description>This integration test checks that the tests selected are only those
+    that reach a changed class or it's subclasses, but neither tests of
+    unrelated siblings nor superclasses.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>touch</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>starts</goal>
+            </goals>
+            <configuration>
+              <useThirdParty>true</useThirdParty>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/setup.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/setup.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.SetupUtil;
+
+setupUtil = new SetupUtil(new File(basedir, ".starts/deps.zlc"))
+file = new File(basedir, "src/main/java/inter/Child.java");
+setupUtil.replaceAllInFile(file, "Set<Integer>", "Set")

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Base.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Base.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Base {
+    protected LinkedHashSet output;
+
+    public Base() {
+        super();
+        output = new LinkedHashSet();
+    }
+
+    public void add(int a) {
+        output.add(a);
+    }
+
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Child.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Child.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import java.util.Set;
+
+public class Child extends Base {
+    @Override
+    public Set<Integer> getSet() {
+        return output;
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/GrandChild.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/GrandChild.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class GrandChild extends Child {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Sibling.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/main/java/inter/Sibling.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+public class Sibling extends Base {
+
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/BaseTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/BaseTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class BaseTest {
+    @Test
+    public void test() {
+        Base base = new Base();
+        base.add(1);
+        base.add(2);
+        base.add(3);
+        Set<Integer> out = base.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/ChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/ChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class ChildTest {
+    @Test
+    public void test() {
+        Child son = new Child();
+        son.add(1);
+        son.add(2);
+        son.add(3);
+        Set<Integer> out = son.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/GrandChildTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/GrandChildTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class GrandChildTest {
+    @Test
+    public void test() {
+        GrandChild grand = new GrandChild();
+        grand.add(1);
+        grand.add(2);
+        grand.add(3);
+        Set<Integer> out = grand.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/SiblingTest.java
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/src/test/java/inter/SiblingTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+package inter;
+
+import org.junit.Test;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+
+public class SiblingTest {
+    @Test
+    public void test() {
+        Sibling cousin = new Sibling();
+        cousin.add(1);
+        cousin.add(2);
+        cousin.add(3);
+        Set<Integer> out = cousin.getSet();
+        int result = 0;
+        for (Integer i : out) {
+            result += i;
+        }
+        assertEquals("sum", 6, result);
+    }
+}

--- a/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/verify.groovy
+++ b/starts-plugin/src/it/multilevel-no-parents-or-siblings-thirdparty-it/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - Present. The STARTS Team. All Rights Reserved.
+ */
+
+import edu.illinois.starts.jdeps.VerifyUtil;
+
+firstRun = new File(basedir, "first-run.txt");
+verifyUtil = new VerifyUtil(new File(basedir, "build.log"));
+
+if (!firstRun.exists()) {
+    firstRun.createNewFile();
+    verifyUtil.assertCorrectlyAffected("4");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertContains("Running inter.SiblingTest");
+    verifyUtil.assertContains("Running inter.BaseTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+} else {
+    verifyUtil.assertCorrectlyAffected("2");
+    verifyUtil.assertContains("Running inter.ChildTest");
+    verifyUtil.assertNotContains("Running inter.SiblingTest");
+    verifyUtil.assertNotContains("Running inter.BaseTest");
+    verifyUtil.assertContains("Running inter.GrandChildTest");
+    verifyUtil.deleteFile(firstRun);
+    verifyUtil.deleteFile(new File(basedir, ".starts/deps.zlc"));
+}

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import edu.illinois.starts.constants.StartsConstants;
+import edu.illinois.starts.data.ZLCFormat;
 import edu.illinois.starts.enums.DependencyFormat;
 import edu.illinois.starts.helpers.EkstaziHelper;
 import edu.illinois.starts.helpers.RTSUtil;
@@ -41,6 +42,14 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
      */
     @Parameter(property = "cleanBytes", defaultValue = TRUE)
     protected boolean cleanBytes;
+
+    /**
+     * Format of the ZLC dependency file deps.zlc
+     * Set to "INDEXED" to store indices of tests
+     * Set to "PLAIN_TEXT" to store full URLs of tests
+     */
+    @Parameter(property = "zlcFormat", defaultValue = "PLAIN_TEXT")
+    protected ZLCFormat zlcFormat;
 
     /**
      * Set this to "true" to update test dependencies on disk. The default value of "false"
@@ -106,7 +115,7 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
             Set<String> unreached = computeUnreached ? result.getUnreachedDeps() : new HashSet<String>();
             if (depFormat == DependencyFormat.ZLC) {
                 ZLCHelper zlcHelper = new ZLCHelper();
-                zlcHelper.updateZLCFile(testDeps, loader, getArtifactsDir(), unreached, useThirdParty);
+                zlcHelper.updateZLCFile(testDeps, loader, getArtifactsDir(), unreached, useThirdParty, zlcFormat);
             } else if (depFormat == DependencyFormat.CLZ) {
                 // The next line is not needed with ZLC because '*' is explicitly tracked in ZLC
                 affectedTests = result.getAffectedTests();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
@@ -107,7 +107,8 @@ public class ImpactedMojo extends DiffMojo implements StartsConstants {
         ClassLoader loader = createClassLoader(sfClassPath);
         Result result = prepareForNextRun(sfPathString, sfClassPath, allClasses, new HashSet<String>(), false);
         ZLCHelper zlcHelper = new ZLCHelper();
-        zlcHelper.updateZLCFile(result.getTestDeps(), loader, getArtifactsDir(), new HashSet<String>(), useThirdParty);
+        zlcHelper.updateZLCFile(result.getTestDeps(), loader, getArtifactsDir(), new HashSet<String>(), useThirdParty,
+                zlcFormat);
         long end = System.currentTimeMillis();
         if (writePath || logger.getLoggingLevel().intValue() <= Level.FINER.intValue()) {
             Writer.writeClassPath(sfPathString, getArtifactsDir());

--- a/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
+++ b/starts-plugin/src/test/java/edu/illinois/starts/jdeps/VerifyUtil.java
@@ -33,6 +33,14 @@ public class VerifyUtil implements StartsConstants {
         }
     }
 
+    public void assertContains(String value) {
+        Assert.assertTrue("Log should contains string: " + value, buildLog.contains(value));
+    }
+
+    public void assertNotContains(String value) {
+        Assert.assertFalse("Log shouldn't contains string: " + value, buildLog.contains(value));
+    }
+
     public void deleteFile(File file) {
         if (file.exists()) {
             file.delete();


### PR DESCRIPTION
A parameter `zlcFormat` is added, which controls how the deps.zlc is stored. It can be set to `PLAIN_TEXT` or `INDEXED`.
If set to `PLAIN_TEXT`, deps.zlc behaviors the same as before.
If set to `INDEXED`, indices of tests are stored in deps.zlc, instead of the full URLs.

An integration test is added for `zlcFormat=INDEXED`. The test is copied from `multilevel-no-parents-or-siblings-it`.