### PR TITLE
fixed a flaky test in WriterTest

### DIFF
--- a/starts-core/src/test/java/edu/illinois/starts/helpers/WriterTest.java
+++ b/starts-core/src/test/java/edu/illinois/starts/helpers/WriterTest.java
@@ -100,10 +100,8 @@ public class WriterTest {
         String[] edges = {"A,B", "C,D"};
         writeToGraph(edges);
         lines = Files.readAllLines(path, charset);
-        String line = lines.get(0);
-        assertEquals("A B", line);
-        line = lines.get(1);
-        assertEquals("C D", line);
+        assertTrue(lines.contains("A B"));
+        assertTrue(lines.contains("C D"));
         assertEquals(2, lines.size());
     }
 


### PR DESCRIPTION
The test `edu.illinois.starts.helpers.WriterTest#testWriteGrpahWithMultipleEdges` is flaky since the `writeToGraph` method ultimately utilizes `HashIterator` in `HashMap`. This iterator does not have a specified iteration order and can return the
map’s elements in any order. 
I changed the ordered string comparison to `List.contains` to avoid flakiness in this test.