### PR TITLE
Add setter for trackNewClasses

### DIFF
--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
@@ -100,6 +100,10 @@ public class ImpactedMojo extends DiffMojo implements StartsConstants {
         this.updateImpactedChecksums = updateImpactedChecksums;
     }
 
+    public void setTrackNewClasses(boolean trackNewClasses) {
+        this.trackNewClasses = trackNewClasses;
+    }
+
     public void execute() throws MojoExecutionException {
         Logger.getGlobal().setLoggingLevel(Level.parse(loggingLevel));
         logger = Logger.getGlobal();


### PR DESCRIPTION
I need to have this setter to obtain the set of new classes for the first run of optimized emop. Otherwise when I try to get new classes, a `NullPointerException` will occur.