### PR TITLE
Make STARTS directory path configurable

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
+++ b/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
@@ -10,8 +10,6 @@ import java.io.File;
  * Some constants used throughout the STARTS codebase.
  */
 public interface StartsConstants {
-    String STARTS_DIRECTORY_PATH = ".starts" + File.separator;
-
     String SUREFIRE_PLUGIN_VM = "org/apache/maven/plugin/surefire/SurefirePlugin";
     String SUREFIRE_PLUGIN_BIN = "org.apache.maven.plugin.surefire.SurefirePlugin";
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/BaseMojo.java
@@ -43,6 +43,12 @@ import org.apache.maven.surefire.util.DefaultScanResult;
 abstract class BaseMojo extends SurefirePlugin implements StartsConstants {
     static final String STAR = "*";
     /**
+     * The name in which the STARTS artifacts directory uses.
+     */
+    @Parameter(property = "startsDirectoryPath", defaultValue = ".starts")
+    protected String startsDirectoryPath;
+
+    /**
      * Set this to "false" to not filter out "sun.*" and "java.*" classes from jdeps parsing.
      */
     @Parameter(property = "filterLib", defaultValue = TRUE)
@@ -100,7 +106,7 @@ abstract class BaseMojo extends SurefirePlugin implements StartsConstants {
 
     public String getArtifactsDir() throws MojoExecutionException {
         if (artifactsDir == null) {
-            artifactsDir = basedir.getAbsolutePath() + File.separator + STARTS_DIRECTORY_PATH;
+            artifactsDir = basedir.getAbsolutePath() + File.separator + startsDirectoryPath + File.separator;
             File file = new File(artifactsDir);
             if (!file.mkdirs() && !file.exists()) {
                 throw new MojoExecutionException("I could not create artifacts dir: " + artifactsDir);


### PR DESCRIPTION
With this change in place, one can configure which directory to store `STARTS` artifacts. Besides, the constant in the interface was only invoked in one place, so making this change would not affect other parts of the program. This functionality is also necessary for running `emop` experiments in parallel.