### PR TITLE
Run all tests for unsupported surefire versions

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
+++ b/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
@@ -11,8 +11,8 @@ import java.io.File;
  */
 public interface StartsConstants {
     String STARTS_DIRECTORY_PATH = ".starts" + File.separator;
-    String MIN_SUREFIRE_VERSION = "2.13";
 
+    String MIN_SUREFIRE_VERSION = "2.13";
     String SUREFIRE_PLUGIN_VM = "org/apache/maven/plugin/surefire/SurefirePlugin";
     String SUREFIRE_PLUGIN_BIN = "org.apache.maven.plugin.surefire.SurefirePlugin";
 

--- a/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
+++ b/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
@@ -11,6 +11,7 @@ import java.io.File;
  */
 public interface StartsConstants {
     String STARTS_DIRECTORY_PATH = ".starts" + File.separator;
+    String MIN_SUREFIRE_VERSION = "2.13";
 
     String SUREFIRE_PLUGIN_VM = "org/apache/maven/plugin/surefire/SurefirePlugin";
     String SUREFIRE_PLUGIN_BIN = "org.apache.maven.plugin.surefire.SurefirePlugin";

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/PomUtil.java
@@ -20,9 +20,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 /**
  * Utility methods for manipulating pom.xml files.
  */
-public class PomUtil {
-    static final String MIN_SUREFIRE_VERSION = "2.13";
-
+public class PomUtil implements StartsConstants {
     public static String extractParamValue(Plugin plugin, String elem) throws MojoExecutionException {
         String value = null;
         Xpp3Dom dom = (Xpp3Dom) plugin.getConfiguration();
@@ -54,20 +52,19 @@ public class PomUtil {
 
     public static Plugin getSfPlugin(MavenProject project) throws MojoExecutionException {
         Plugin sfPlugin = lookupPlugin("org.apache.maven.plugins:maven-surefire-plugin", project);
-        checkSFVersion(sfPlugin);
-        return sfPlugin;
-    }
-
-    public static void checkSFVersion(Plugin sfPlugin) throws MojoExecutionException {
         if (sfPlugin == null) {
             throw new MojoExecutionException("Surefire plugin not available");
         }
+        return sfPlugin;
+    }
 
-        String version = sfPlugin.getVersion();
-        if (MIN_SUREFIRE_VERSION.compareTo(version) > 0) {
-            throw new MojoExecutionException("Unsupported Surefire version: " + version
-                    + ". Use version " + MIN_SUREFIRE_VERSION + " and above.");
-        }
+    public static String getSfVersion(MavenProject project) throws MojoExecutionException {
+        return getSfPlugin(project).getVersion();
+    }
+
+    public static boolean invalidSfVersion(MavenProject project) throws MojoExecutionException {
+        String version = getSfVersion(project);
+        return MIN_SUREFIRE_VERSION.compareTo(version) > 0;
     }
 
     public static Plugin lookupPlugin(String name, MavenProject project) {

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
@@ -4,6 +4,9 @@
 
 package edu.illinois.starts.jdeps;
 
+import static edu.illinois.starts.helpers.PomUtil.getSfVersion;
+import static edu.illinois.starts.helpers.PomUtil.invalidSfVersion;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -96,7 +99,12 @@ public class RunMojo extends DiffMojo implements StartsConstants {
     protected void run() throws MojoExecutionException {
         String cpString = Writer.pathToString(getSureFireClassPath().getClassPath());
         List<String> sfPathElements = getCleanClassPath(cpString);
-        if (!isSameClassPath(sfPathElements) || !hasSameJarChecksum(sfPathElements)) {
+        if (invalidSfVersion(getProject())) {
+            logger.log(Level.WARNING, "Unsupported Surefire version: " + getSfVersion(getProject())
+                    + ". Use version " + MIN_SUREFIRE_VERSION + " and above. Running all tests.");
+            // Run all tests
+            dynamicallyUpdateExcludes(new ArrayList<String>());
+        } else if (!isSameClassPath(sfPathElements) || !hasSameJarChecksum(sfPathElements)) {
             // Force retestAll because classpath changed since last run
             // don't compute changed and non-affected classes
             dynamicallyUpdateExcludes(new ArrayList<String>());

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/RunMojo.java
@@ -104,14 +104,15 @@ public class RunMojo extends DiffMojo implements StartsConstants {
                     + ". Use version " + MIN_SUREFIRE_VERSION + " and above. Running all tests.");
             // Run all tests
             dynamicallyUpdateExcludes(new ArrayList<String>());
+            nonAffectedTests = new HashSet<>();
         } else if (!isSameClassPath(sfPathElements) || !hasSameJarChecksum(sfPathElements)) {
             // Force retestAll because classpath changed since last run
             // don't compute changed and non-affected classes
             dynamicallyUpdateExcludes(new ArrayList<String>());
             // Make nonAffected empty so dependencies can be updated
             nonAffectedTests = new HashSet<>();
-            Writer.writeClassPath(cpString, artifactsDir);
-            Writer.writeJarChecksums(sfPathElements, artifactsDir, jarCheckSums);
+            Writer.writeClassPath(cpString, getArtifactsDir());
+            Writer.writeJarChecksums(sfPathElements, getArtifactsDir(), jarCheckSums);
         } else if (retestAll) {
             // Force retestAll but compute changes and affected tests
             setChangedAndNonaffected();


### PR DESCRIPTION
Closes #63 

`mvn starts:starts` prints out a message "Unsupported Surefire version: 2.12. Use version 2.13 and above. Running all tests." at the `WARNING` log level.

<img width="1440" alt="screenshot" src="https://user-images.githubusercontent.com/34158284/198913679-1709d9fc-2c5a-4b6d-8823-4a98f9bd8c24.png">
