### PR TITLE
bug fix for nullptrexception

### DIFF
--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/ImpactedMojo.java
@@ -116,6 +116,9 @@ public class ImpactedMojo extends DiffMojo implements StartsConstants {
         List<String> allClasses = getAllClasses();
         if (allClasses.isEmpty()) {
             logger.log(Level.INFO, "There are no .class files in this module.");
+            oldClasses = new HashSet<>();
+            newClasses = new HashSet<>();
+            impacted = new HashSet<>();
             return;
         }
         impacted = new HashSet<>(allClasses);


### PR DESCRIPTION
Currently, if there are no `.class` files in the subject, then the fields `oldClasses`, `newClasses`, `impacted` will all be null, causing the methods `getOldClasses()`, `getNewClasses()`, and `getImpacted()` to throw NullPointerExceptions. This is a quick fix for the NullPointerException issue.