### PR TITLE
Change TransitiveClosureOptions to be PS1, PS2, PS3

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/enums/TransitiveClosureOptions.java
+++ b/starts-core/src/main/java/edu/illinois/starts/enums/TransitiveClosureOptions.java
@@ -15,14 +15,14 @@ package edu.illinois.starts.enums;
  * }
  * The options will return the following values when performed on B:
  * {@literal
- *     TRANSITIVE --> [B, C, TC]
- *     TRANSITIVE_AND_INVERSE_TRANSITIVE --> [A, B, C, TC]
- *     TRANSITIVE_OF_INVERSE_TRANSITIVE --> [A, B, C, D, TC]
+ *     PS1 --> [A, B, C, D, TC]
+ *     PS2 --> [A, B, C, TC]
+ *     PS3 --> [B, C, TC]
  * }
  * These options correspond to ps3, ps2, and ps1, respectively, in the aforementioned paper
  */
 public enum TransitiveClosureOptions {
-    TRANSITIVE,
-    TRANSITIVE_AND_INVERSE_TRANSITIVE,
-    TRANSITIVE_OF_INVERSE_TRANSITIVE,
+    PS1,
+    PS2,
+    PS3,
 }

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
@@ -215,16 +215,16 @@ public class Loadables implements StartsConstants {
             HashSet<String> nodeSet = new HashSet<>(Arrays.asList(analyzedClass));
             Set<String> transitiveClosure = new HashSet<>();
             switch (closureOption) {
-                case TRANSITIVE:
+                case PS3:
                     transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
                     break;
-                case TRANSITIVE_AND_INVERSE_TRANSITIVE:
+                case PS2:
                     transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
                     transitiveClosure.addAll(YasglHelper.reverseReachabilityFromChangedClasses(nodeSet, tcGraph));
                     break;
-                case TRANSITIVE_OF_INVERSE_TRANSITIVE:
+                case PS1:
                     transitiveClosure = YasglHelper.reverseReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
                     transitiveClosure.addAll(YasglHelper.computeReachabilityFromChangedClasses(transitiveClosure, tcGraph));

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/Loadables.java
@@ -215,19 +215,19 @@ public class Loadables implements StartsConstants {
             HashSet<String> nodeSet = new HashSet<>(Arrays.asList(analyzedClass));
             Set<String> transitiveClosure = new HashSet<>();
             switch (closureOption) {
-                case PS3:
-                    transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);
+                case PS1:
+                    transitiveClosure = YasglHelper.reverseReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
+                    transitiveClosure.addAll(YasglHelper.computeReachabilityFromChangedClasses(transitiveClosure, tcGraph));
                     break;
                 case PS2:
                     transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
                     transitiveClosure.addAll(YasglHelper.reverseReachabilityFromChangedClasses(nodeSet, tcGraph));
                     break;
-                case PS1:
-                    transitiveClosure = YasglHelper.reverseReachabilityFromChangedClasses(nodeSet, tcGraph);
+                case PS3:
+                    transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);
                     transitiveClosure.add(analyzedClass);
-                    transitiveClosure.addAll(YasglHelper.computeReachabilityFromChangedClasses(transitiveClosure, tcGraph));
                     break;
                 default:
                     transitiveClosure = YasglHelper.computeReachabilityFromChangedClasses(nodeSet, tcGraph);

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/DiffMojo.java
@@ -111,7 +111,7 @@ public class DiffMojo extends BaseMojo implements StartsConstants {
             //TODO: set this boolean to true only for static reflectionAnalyses with * (border, string, naive)?
             boolean computeUnreached = true;
             Result result = prepareForNextRun(sfPathString, sfClassPath, allTests, nonAffected,
-                    computeUnreached, TransitiveClosureOptions.TRANSITIVE);
+                    computeUnreached, TransitiveClosureOptions.PS3);
             Map<String, Set<String>> testDeps = result.getTestDeps();
             graph = result.getGraph();
             Set<String> unreached = computeUnreached ? result.getUnreachedDeps() : new HashSet<String>();


### PR DESCRIPTION
Rename TransitiveClosureOptions enum values in accordance with eMOP's Issue `#68` (https://github.com/SoftEngResearch/emop/issues/68).