### PR TITLE
Optimize graph building

### DIFF
--- a/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
+++ b/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
@@ -67,6 +67,7 @@ public interface StartsConstants {
     String TARGET = "target";
     String METHODS_TEST_DEPS_ZLC_FILE = "methods-deps.zlc";
     String METHODS_CHECKSUMS_SERIALIZED_FILE = "methods-checksums.ser";
+    String METHODS_DEPENDENCIES_SERIALIZED_FILE = "methods-dependencies.ser";
     String CLASSES_ZLC_FILE = "classes-checksums.zlc";
     String CLASSES_CHECKSUM_SERIALIZED_FILE = "classes-checksums.ser";
 

--- a/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
+++ b/starts-core/src/main/java/edu/illinois/starts/constants/StartsConstants.java
@@ -70,6 +70,9 @@ public interface StartsConstants {
     String METHODS_DEPENDENCIES_SERIALIZED_FILE = "methods-dependencies.ser";
     String CLASSES_ZLC_FILE = "classes-checksums.zlc";
     String CLASSES_CHECKSUM_SERIALIZED_FILE = "classes-checksums.ser";
+    String CLASSES_DEPENDENCIES_SERIALIZED_FILE = "classes-dependencies.ser";
+    String HIERARCHY_CHILDREN_SERIALIZED_FILE = "hierarchy-children.ser";
+    String HIERARCHY_PARENTS_SERIALIZED_FILE = "hierarchy-parents.ser";
 
     // Used in smethods
     String SMETHODS_ROOT_DIR_NAME = ".smethods";

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelperMethods.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelperMethods.java
@@ -47,18 +47,15 @@ public class ZLCHelperMethods implements StartsConstants {
      * @param artifactsDir        The directory where the serialized file is saved.
      * @param newMethodsChecksums A map containing the method names and their
      *                            checksums.
-     * @param methodToTestClasses A map from method names to their test classes/
      * @return A list of sets containing all the information described above.
      */
 
-    public static List<Set<String>> getChangedDataMethods(Map<String, String> newMethodsChecksums,
-            Map<String, Set<String>> methodToTestClasses, String artifactsDir, String filepath) {
+    public static List<Set<String>> getChangedDataMethods(Map<String, String> newMethodsChecksums, String artifactsDir,
+            String filepath) {
         long start = System.currentTimeMillis();
 
         Map<String, String> oldMethodChecksums = deserializeMapping(artifactsDir, filepath);
-
         Set<String> changedMethods = new HashSet<>();
-        Set<String> affectedTests = new HashSet<>();
         Set<String> oldClasses = new HashSet<>();
         Set<String> changedClasses = new HashSet<>();
         Set<String> newMethods = new HashSet<>(newMethodsChecksums.keySet());
@@ -66,7 +63,6 @@ public class ZLCHelperMethods implements StartsConstants {
         for (String method : oldMethodChecksums.keySet()) {
             String oldChecksum = oldMethodChecksums.get(method);
             String newChecksum = newMethodsChecksums.get(method);
-            Set<String> deps = methodToTestClasses.getOrDefault(method, new HashSet<>());
             String className = method.split("#")[0];
 
             oldClasses.add(className);
@@ -77,7 +73,6 @@ public class ZLCHelperMethods implements StartsConstants {
                 continue;
             } else {
                 changedMethods.add(method);
-                affectedTests.addAll(deps);
                 changedClasses.add(className);
             }
         }
@@ -87,7 +82,7 @@ public class ZLCHelperMethods implements StartsConstants {
         for (String method : newMethods) {
             changedClasses.add(method.split("#")[0]);
         }
-        Collections.addAll(result, changedMethods, newMethods, affectedTests, oldClasses, changedClasses);
+        Collections.addAll(result, changedMethods, newMethods, oldClasses, changedClasses);
         LOGGER.log(Level.FINEST, TIME_COMPUTING_NON_AFFECTED + (end - start) + MILLISECOND);
         return result;
     }
@@ -129,7 +124,8 @@ public class ZLCHelperMethods implements StartsConstants {
      * classes without changed headers.
      * It also constructs a methods checksums map for next run.
      */
-    public static List<Set<String>> getChangedDataHybridMethodLevel(Set<String> addedClasses, Set<String> deletedClasses,
+    public static List<Set<String>> getChangedDataHybridMethodLevel(Set<String> addedClasses,
+            Set<String> deletedClasses,
             Set<String> changedClassesWithChangedHeaders, Set<String> changedClassesWithoutChangedHeaders,
             Map<String, String> methodChecksums,
             ClassLoader loader,
@@ -147,10 +143,8 @@ public class ZLCHelperMethods implements StartsConstants {
         Map<String, String> changedClassesWithoutChangedHeadersMethodsChecksums = MethodLevelStaticDepsBuilder
                 .getMethodsChecksumsForClasses(changedClassesWithoutChangedHeaders, loader);
 
-
         List<Set<String>> changedAndNewMethodsForMethodAnalysis = findChangedAndNewMethods(oldMethodsChecksums,
                 changedClassesWithoutChangedHeadersMethodsChecksums);
-
 
         // Constructing a methods checksums map for next run
         Set<String> modifiedOldClasses = new HashSet<>();
@@ -313,7 +307,7 @@ public class ZLCHelperMethods implements StartsConstants {
      *                                found.
      */
     @SuppressWarnings("unchecked")
-    private static <T> Map<String, T> deserializeMapping(String artifactsDir, String filename) {
+    public static <T> Map<String, T> deserializeMapping(String artifactsDir, String filename) {
         Map<String, T> map = new HashMap<>();
         try {
             FileInputStream fis = new FileInputStream(artifactsDir + filename);

--- a/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelperMethods.java
+++ b/starts-core/src/main/java/edu/illinois/starts/helpers/ZLCHelperMethods.java
@@ -39,8 +39,8 @@ public class ZLCHelperMethods implements StartsConstants {
 
     /**
      * This helper method is used in method-level analysis returns a list of sets
-     * containing information about changed methods, new methods, affected tests,
-     * old classes, and changed classes.
+     * containing information about changed methods, new methods, old classes, and
+     * changed classes.
      * This method is called from MethodMojo.java from the setChangedMethods()
      * method.
      *

--- a/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
+++ b/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
@@ -96,8 +96,8 @@ public class MethodLevelStaticDepsBuilder {
                     .filter(f -> (f.toString().endsWith(".class") && f.toString().contains("target")))
                     .map(f -> f.normalize().toAbsolutePath().toString())
                     .collect(Collectors.toList()));
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (Exception exception) {
+            exception.printStackTrace();
         }
         return class_paths;
     }
@@ -447,7 +447,6 @@ public class MethodLevelStaticDepsBuilder {
 
     /**
      * This function Computes and returns the methodToTestClasses map.
-     * 
      * @return methodToTestClasses method to test classes mapping
      */
     public static Map<String, Set<String>> computeMethodToTestClasses(boolean includeVariables) {

--- a/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
+++ b/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
@@ -77,6 +77,191 @@ public class MethodLevelStaticDepsBuilder {
 
     private static final Logger LOGGER = Logger.getGlobal();
 
+    private static HashSet<String> class_paths = null;
+
+    private static Map<String, String> classNameToPathMap = null;
+
+    /*
+     * This function returns all the classes' paths in the project.
+     */
+    public static HashSet<String> getAllClassesPaths() {
+        if (class_paths != null) {
+            return class_paths;
+        }
+        try {
+            class_paths = new HashSet<>(Files.walk(Paths.get("."))
+                    .filter(Files::isRegularFile)
+                    .filter(f -> (f.toString().endsWith(".class") && f.toString().contains("target")))
+                    .map(f -> f.normalize().toAbsolutePath().toString())
+                    .collect(Collectors.toList()));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return class_paths;
+    }
+
+    /*
+     * This function returns a map from class name to class path.
+     * e.g., com/example/A ->
+     * /home/mopuser/earv-research/starts-example/target/classes/com/example/A.class
+     */
+    public static Map<String, String> getClassNameToPathMap() {
+        if (classNameToPathMap != null) {
+            return classNameToPathMap;
+        }
+        classNameToPathMap = new HashMap<>();
+        for (String classPath : getAllClassesPaths()) {
+            String className = getClassNameFromClassPath(classPath);
+            classNameToPathMap.put(className, classPath);
+        }
+        return classNameToPathMap;
+    }
+
+    /*
+     * This function returns all the classes' Names in the project.
+     */
+    public static HashSet<String> getAllClassesNames() {
+        HashSet<String> classPaths = getAllClassesPaths();
+        HashSet<String> classes = new HashSet<>();
+        for (String classPath : classPaths) {
+            String className = getClassNameFromClassPath(classPath);
+            classes.add(className);
+        }
+        return classes;
+    }
+
+    /*
+     * This function returns the class name from the class path.
+     * e.g.,
+     * /home/mopuser/earv-research/starts-example/target/classes/com/example/B.class
+     * -> com/example/B
+     */
+    public static String getClassNameFromClassPath(String classPath) {
+        String className = classPath.substring(classPath.indexOf("classes/") + "classes/".length(),
+                classPath.length() - ".class".length());
+        return className;
+    }
+
+    /*
+     * This function returns the classes' paths for set of classes' names.
+     */
+    public static Set<String> getClassPathsForSetOfClassNames(Set<String> classesNames) {
+        Set<String> classesPaths = new HashSet<>();
+        Map<String, String> classNameToPathMap = getClassNameToPathMap();
+        for (String className : classesNames) {
+            String classPath = classNameToPathMap.get(className);
+            classesPaths.add(classPath);
+        }
+        return classesPaths;
+    }
+
+    /*
+     * This function returns the class path for the given class name.
+     */
+    public static String getClassPathForClassName(String className) {
+        String classPath = null;
+        Map<String, String> classNameToPathMap = getClassNameToPathMap();
+        classPath = classNameToPathMap.get(className);
+        return classPath;
+    }
+
+    /*
+     * This function computes methods checksums for all the methods in the project.
+     * It returns a map containing them.
+     */
+    public static Map<String, String> computeAllMethodsChecksums() {
+        HashSet<String> classPaths = getAllClassesPaths();
+        Map<String, String> computedMethodsChecksums = new HashMap<>();
+        for (String classPath : classPaths) {
+
+            ClassNode node = new ClassNode(Opcodes.ASM5);
+            ClassReader reader = null;
+            try {
+                reader = new ClassReader(new FileInputStream(classPath));
+            } catch (IOException exception) {
+                LOGGER.log(Level.INFO, "[ERROR] reading class: " + classPaths);
+                continue;
+            }
+
+            String methodChecksum = null;
+            reader.accept(node, ClassReader.SKIP_DEBUG);
+            List<MethodNode> methods = node.methods;
+            String className = node.name;
+
+            // Looping over all the methods in the class, and computing the checksum for
+            // each method
+            for (MethodNode method : methods) {
+                String methodContent = ZLCHelperMethods.printMethodContent(method);
+                try {
+                    methodChecksum = ChecksumUtil.computeStringChecksum(methodContent);
+                } catch (IOException exception) {
+                    throw new RuntimeException(exception);
+                }
+                computedMethodsChecksums.put(
+                        className + "#" + method.name + method.desc.substring(0, method.desc.indexOf(")") + 1),
+                        methodChecksum);
+            }
+        }
+        return computedMethodsChecksums;
+    }
+
+    /*
+     * This function builds the method dependency graph for all the methods in the
+     * project.
+     */
+    public static Map<String, Set<String>> buildMethodsDependencyGraph(HashSet<String> classPathsSet,
+            boolean includeVariables,
+            boolean includeTestMethods) {
+        findMethodsinvoked(classPathsSet);
+        if (includeTestMethods) {
+            // Suppose that test classes have Test in their class name
+            // and are in src/test
+            Set<String> testClasses = new HashSet<>();
+            for (String method : methodNameToMethodNames.keySet()) {
+                String className = method.split("#|\\$")[0];
+                if (className.contains("Test")) {
+                    testClasses.add(className);
+                }
+            }
+
+            // Finding Test Classes to methods
+            testClassesToMethods = getDepsSingleThread(testClasses);
+        }
+
+        addReflexiveClosure(methodNameToMethodNames);
+        /*
+         * Adding reflexive closure to methodNameToMethodNames
+         * A -> B
+         * It will be:
+         * A -> A, B
+         */
+        addReflexiveClosure(methodNameToMethodNames);
+
+        // Inverting methodNameToMethodNames to have the dependency graph for each
+        // method
+        // methodNameToMethodNames = invertMap(methodNameToMethodNames);
+        methodDependencyGraph = invertMap(methodNameToMethodNames);
+
+        if (includeVariables) {
+            /*
+             * The original dependency graph is like this:
+             * (A, B, C) are classes
+             * (a) is a variable
+             * A -> A, B, C
+             * a -> A
+             * After this function call the dependency graph will be like this:
+             * A -> A, B, C, a
+             * a -> A
+             */
+            addVariableDepsToDependencyGraph();
+        } else {
+            // Remove any variables from keys or values i.e. pure method-level deps
+            filterVariables();
+        }
+
+        return null;
+    }
+
     /**
      * This function builds the method dependency graph for all the methods in the
      * project.

--- a/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
+++ b/starts-core/src/main/java/edu/illinois/starts/smethods/MethodLevelStaticDepsBuilder.java
@@ -436,7 +436,6 @@ public class MethodLevelStaticDepsBuilder {
 
     /**
      * This function Computes and returns the methodToTestClasses map.
-     * 
      * @return methodToTestClasses method to test classes mapping
      */
     public static Map<String, Set<String>> computeMethodToTestClasses(boolean includeVariables) {

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
@@ -199,8 +199,7 @@ public class HybridMojo extends DiffMojo {
                 MethodLevelStaticDepsBuilder.buildMethodsGraph(includeVariables);
                 classesChecksum = MethodLevelStaticDepsBuilder.computeClassesChecksums(loader, cleanBytes);
                 methodsCheckSum = MethodLevelStaticDepsBuilder.computeAllMethodsChecksums();
-                methodsDependencyGraph = MethodLevelStaticDepsBuilder.buildMethodsDependencyGraph(includeVariables,
-                        computeAffectedTests);
+                methodsDependencyGraph = MethodLevelStaticDepsBuilder.buildMethodsDependencyGraph(includeVariables);
                 classesDependencyGraph = MethodLevelStaticDepsBuilder.constructClassesDependencyGraph();
 
             } catch (Exception exception) {
@@ -265,13 +264,13 @@ public class HybridMojo extends DiffMojo {
 
             methodsDependencyGraph = MethodLevelStaticDepsBuilder
                     .buildMethodsDependencyGraphUsingOldGraphAndChangedClasses(oldMethodsDependencyGraph,
-                            changedClasses, newClasses, includeVariables, computeAffectedTests);
+                            changedClasses, newClasses, includeVariables);
 
             // Updating Hierarchy Parents and Children Maps because they are used in
             // building class dependency graph
             Map<String, Set<String>> hierarchyParents = ZLCHelperMethods.deserializeMapping(getArtifactsDir(),
                     HIERARCHY_PARENTS_SERIALIZED_FILE);
-            MethodLevelStaticDepsBuilder.updateHierarchyParents(hierarchyParents);
+            MethodLevelStaticDepsBuilder.constructHierarchyParentsFromOld(hierarchyParents);
 
             // Building Class Dependency Graph
             classesDependencyGraph = MethodLevelStaticDepsBuilder.constructClassesDependencyGraph();

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
@@ -15,6 +15,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import edu.illinois.starts.helpers.ZLCHelperMethods;
+import edu.illinois.starts.smethods.MethodLevelStaticDepsBuilder;
+import edu.illinois.starts.util.ChecksumUtil;
+import edu.illinois.starts.util.Logger;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -22,11 +27,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.surefire.booter.Classpath;
-
-import edu.illinois.starts.helpers.ZLCHelperMethods;
-import edu.illinois.starts.smethods.MethodLevelStaticDepsBuilder;
-import edu.illinois.starts.util.ChecksumUtil;
-import edu.illinois.starts.util.Logger;
 
 @Mojo(name = "hybrid", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 @Execute(phase = LifecyclePhase.TEST_COMPILE)
@@ -256,8 +256,6 @@ public class HybridMojo extends DiffMojo {
                 throw new RuntimeException(exception);
             }
             setChangedMethodsAndChangedClasses();
-
-            
 
             // Building Method Dependency Graph
             Map<String, Set<String>> oldMethodsDependencyGraph = ZLCHelperMethods.deserializeMapping(getArtifactsDir(),

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
@@ -173,7 +173,7 @@ public class HybridMojo extends DiffMojo {
 
             classesChecksum = MethodLevelStaticDepsBuilder.computeClassesChecksums(loader, cleanBytes);
             if (computeAffectedTests) {
-                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses();
+                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses(includeVariables);
             }
         } catch (Exception exception) {
             throw new RuntimeException(exception);
@@ -217,7 +217,7 @@ public class HybridMojo extends DiffMojo {
             nonAffectedMethods = new HashSet<>();
 
             if (computeAffectedTests) {
-                affectedTestClasses = MethodLevelStaticDepsBuilder.computeTestClasses();
+                affectedTestClasses = MethodLevelStaticDepsBuilder.computeTestClasses(includeVariables);
             }
 
             if (impacted) {
@@ -244,7 +244,7 @@ public class HybridMojo extends DiffMojo {
             MethodLevelStaticDepsBuilder.constuctTestClassesToClassesGraph();
             if (computeAffectedTests) {
                 classToTestClassGraph = MethodLevelStaticDepsBuilder.constructClassesToTestClassesGraph();
-                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses();
+                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses(includeVariables);
                 affectedTestClasses = new HashSet<>();
             }
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/HybridMojo.java
@@ -167,19 +167,7 @@ public class HybridMojo extends DiffMojo {
         Classpath sfClassPath = getSureFireClassPath();
         loader = createClassLoader(sfClassPath);
 
-        // Build method level static dependencies
-        try {
-            MethodLevelStaticDepsBuilder.buildMethodsGraph(includeVariables);
-
-            classesChecksum = MethodLevelStaticDepsBuilder.computeClassesChecksums(loader, cleanBytes);
-            if (computeAffectedTests) {
-                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses(includeVariables);
-            }
-        } catch (Exception exception) {
-            throw new RuntimeException(exception);
-        }
-
-        runHybrid(computeImpactedMethods);
+        runHybrid();
     }
 
     /**
@@ -194,12 +182,23 @@ public class HybridMojo extends DiffMojo {
      * It also updates the methods checksums in the dependency file if
      * updateMethodsChecksums is true.
      *
-     * @param impacted a boolean value indicating whether to compute impacted
-     *                 methods and impacted test classes
      * @throws MojoExecutionException if an exception occurs while setting changed
      *                                methods
      */
-    protected void runHybrid(boolean impacted) throws MojoExecutionException {
+    protected void runHybrid() throws MojoExecutionException {
+
+        // Build method level static dependencies
+        try {
+            MethodLevelStaticDepsBuilder.buildMethodsGraph(includeVariables);
+
+            classesChecksum = MethodLevelStaticDepsBuilder.computeClassesChecksums(loader, cleanBytes);
+            if (computeAffectedTests) {
+                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses(includeVariables);
+            }
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+
         // Checking if the file of dependencies exists (first run)
         if (!Files.exists(Paths.get(getArtifactsDir() + METHODS_CHECKSUMS_SERIALIZED_FILE))
                 && !Files.exists(Paths.get(getArtifactsDir() + CLASSES_CHECKSUM_SERIALIZED_FILE))) {
@@ -220,7 +219,7 @@ public class HybridMojo extends DiffMojo {
                 affectedTestClasses = MethodLevelStaticDepsBuilder.computeTestClasses(includeVariables);
             }
 
-            if (impacted) {
+            if (computeImpactedMethods) {
                 impactedMethods = newMethods;
                 impactedClasses = newClasses;
             }
@@ -250,7 +249,7 @@ public class HybridMojo extends DiffMojo {
 
             setChangedAndNonaffectedMethods();
 
-            if (impacted) {
+            if (computeImpactedMethods) {
                 computeImpactedMethods();
                 computeImpactedClasses();
             }
@@ -270,7 +269,7 @@ public class HybridMojo extends DiffMojo {
 
         }
 
-        logInfo(impacted);
+        logInfo(computeImpactedMethods);
     }
 
     /**

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/MethodsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/MethodsMojo.java
@@ -173,7 +173,7 @@ public class MethodsMojo extends DiffMojo {
             try {
                 methodsCheckSum = MethodLevelStaticDepsBuilder.computeAllMethodsChecksums();
                 methodsDependencyGraph = MethodLevelStaticDepsBuilder.buildMethodsDependencyGraph(
-                        includeVariables, computeAffectedTests);
+                        includeVariables);
             } catch (Exception exception) {
                 throw new RuntimeException(exception);
             }
@@ -222,13 +222,14 @@ public class MethodsMojo extends DiffMojo {
 
             methodsDependencyGraph = MethodLevelStaticDepsBuilder
                     .buildMethodsDependencyGraphUsingOldGraphAndChangedClasses(oldMethodsDependencyGraph,
-                            changedClasses, newClasses, includeVariables, computeAffectedTests);
+                            changedClasses, newClasses, includeVariables);
 
             if (computeImpactedMethods) {
                 computeImpactedMethods();
 
             }
             if (computeAffectedTests) {
+                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses(includeVariables);
                 computeAffectedTestClasses();
             }
 

--- a/starts-plugin/src/main/java/edu/illinois/starts/jdeps/MethodsMojo.java
+++ b/starts-plugin/src/main/java/edu/illinois/starts/jdeps/MethodsMojo.java
@@ -44,6 +44,7 @@ public class MethodsMojo extends DiffMojo {
     private Map<String, String> methodsCheckSum;
     private Map<String, Set<String>> methodToTestClasses;
     private ClassLoader loader;
+    private Map<String, Set<String>> methodsDependencyGraph;
 
     /**
      * Set this to "true" to compute impacted methods as well. False indicates only
@@ -147,17 +148,7 @@ public class MethodsMojo extends DiffMojo {
         logger = Logger.getGlobal();
         Classpath sfClassPath = getSureFireClassPath();
         loader = createClassLoader(sfClassPath);
-
-        // Build method level static dependencies
-        try {
-            MethodLevelStaticDepsBuilder.buildMethodsGraph(includeVariables);
-            methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses();
-            methodsCheckSum = MethodLevelStaticDepsBuilder.computeMethodsChecksum(loader);
-        } catch (Exception exception) {
-            throw new RuntimeException(exception);
-        }
-
-        runMethods(computeImpactedMethods);
+        runMethods();
     }
 
     /**
@@ -172,27 +163,33 @@ public class MethodsMojo extends DiffMojo {
      * It also updates the methods checksums in the dependency file if
      * updateMethodsChecksums is true.
      *
-     * @param impacted a boolean value indicating whether to compute impacted
-     *                 methods and impacted test classes
      * @throws MojoExecutionException if an exception occurs while setting changed
      *                                methods
      */
-    protected void runMethods(boolean impacted) throws MojoExecutionException {
-
+    protected void runMethods() throws MojoExecutionException {
         // Checking if the file of depedencies exists (first run or not)
         if (!Files.exists(Paths.get(getArtifactsDir() + METHODS_CHECKSUMS_SERIALIZED_FILE))) {
+            // Compute Methods Checksums and Build the method level dependencies graph
+            try {
+                methodsCheckSum = MethodLevelStaticDepsBuilder.computeAllMethodsChecksums();
+                HashSet<String> classesPathsSet = MethodLevelStaticDepsBuilder.getAllClassesPaths();
+                methodsDependencyGraph = MethodLevelStaticDepsBuilder.buildMethodsDependencyGraph(classesPathsSet, includeVariables, computeAffectedTests);
+            } catch (Exception exception) {
+                throw new RuntimeException(exception);
+            }
+
             changedMethods = new HashSet<>();
-            newMethods = MethodLevelStaticDepsBuilder.computeMethods();
+            newMethods = methodsCheckSum.keySet();
             oldClasses = new HashSet<>();
             changedClasses = new HashSet<>();
-            newClasses = MethodLevelStaticDepsBuilder.getClasses();
+            newClasses = MethodLevelStaticDepsBuilder.getAllClassesNames();
             nonAffectedMethods = new HashSet<>();
 
             if (computeAffectedTests) {
                 affectedTestClasses = MethodLevelStaticDepsBuilder.computeTestClasses();
             }
 
-            if (impacted) {
+            if (computeImpactedMethods) {
                 impactedMethods = newMethods;
             }
 
@@ -200,15 +197,25 @@ public class MethodsMojo extends DiffMojo {
             try {
                 ZLCHelperMethods.serializeMapping(methodsCheckSum, getArtifactsDir(),
                         METHODS_CHECKSUMS_SERIALIZED_FILE);
+                ZLCHelperMethods.serializeMapping(methodsDependencyGraph, getArtifactsDir(), METHODS_DEPENDENCIES_SERIALIZED_FILE);
             } catch (IOException exception) {
                 exception.printStackTrace();
             }
 
         } else {
+            // Build method level static dependencies
+            try {
+                MethodLevelStaticDepsBuilder.buildMethodsGraph(includeVariables);
+                methodToTestClasses = MethodLevelStaticDepsBuilder.computeMethodToTestClasses();
+                methodsCheckSum = MethodLevelStaticDepsBuilder.computeMethodsChecksum(loader);
+            } catch (Exception exception) {
+                throw new RuntimeException(exception);
+            }
+
             // First run has saved the old revision's checksums. Time to find changes.
             computeChangedMethods();
 
-            if (impacted) {
+            if (computeImpactedMethods) {
                 computeImpactedMethods();
 
             }
@@ -226,7 +233,7 @@ public class MethodsMojo extends DiffMojo {
             }
         }
 
-        logInfoStatements(impacted);
+        logInfoStatements();
     }
 
     /**
@@ -234,14 +241,12 @@ public class MethodsMojo extends DiffMojo {
      * impacted test classes, new classes, old classes and changed classes.
      * If impacted is true, it also logs information about impacted methods.
      *
-     * @param impacted a boolean value indicating whether to log information about
-     *                 impacted methods
      */
-    private void logInfoStatements(boolean impacted) {
+    private void logInfoStatements() {
         logger.log(Level.INFO, "ChangedMethods: " + changedMethods.size());
         logger.log(Level.INFO, "NewMethods: " + newMethods.size());
 
-        if (impacted) {
+        if (computeImpactedMethods) {
             logger.log(Level.INFO, "ImpactedMethods: " + impactedMethods.size());
         }
 


### PR DESCRIPTION
This PR includes the following optimizations for method level and hybrid analysis graph-building functionality
For Method analysis:
Instead of rebuilding the method-level dependency graph from scratch each time, it stores the graph in the first run. In the subsequent runs, It reads the graph and updates it with the changes. Then, it uses the new graph for computations. At the end, it stores the updated graph. 

For Hybrid analysis:
It is similar to method-level analysis. In addition, it uses the method-level graph to build the class-level dependency graph. 